### PR TITLE
Aggregation and SELECT checks

### DIFF
--- a/src/dev/com/yetanalytics/flint/sparql.clj
+++ b/src/dev/com/yetanalytics/flint/sparql.clj
@@ -59,7 +59,7 @@
 
   (QueryFactory/create
    "SELECT (COUNT(DISTINCT ?z) AS ?z)
-    WHERE { ?x a <htgtp://foo.org/Thing> }")
+    WHERE { ?x a <http://foo.org/Thing> }")
 
   (println
    (QueryFactory/create

--- a/src/dev/com/yetanalytics/flint/sparql.clj
+++ b/src/dev/com/yetanalytics/flint/sparql.clj
@@ -39,11 +39,12 @@
 
 (comment
   (QueryFactory/create
-   "SELECT *
+   "SELECT ?a
     WHERE {
       ?x ?y ?z .
+      BIND (?q AS ?w)
     }
-    GROUP BY ?x")
+    GROUP BY (?w AS ?a)")
 
   (QueryFactory/create
    "SELECT (COUNT(DISTINCT ?z) AS ?z)

--- a/src/dev/com/yetanalytics/flint/sparql.clj
+++ b/src/dev/com/yetanalytics/flint/sparql.clj
@@ -39,12 +39,23 @@
 
 (comment
   (QueryFactory/create
-   "SELECT ?a
+   "SELECT (SUM(?x + ?y) AS ?sum) (str(?sum) AS ?z2)
     WHERE {
       ?x ?y ?z .
-      BIND (?q AS ?w)
     }
-    GROUP BY (?w AS ?a)")
+    ORDER BY ?x")
+  (QueryFactory/create
+   "SELECT ((?z + SUM(?y + ?x)) AS ?sum) (?sum AS ?z2)
+    WHERE {
+      ?x ?y ?z .
+    }
+    GROUP BY ?z")
+  (QueryFactory/create
+   "SELECT ?q
+    WHERE {
+      ?x ?y ?z .
+    }
+    GROUP BY ?q")
 
   (QueryFactory/create
    "SELECT (COUNT(DISTINCT ?z) AS ?z)

--- a/src/dev/com/yetanalytics/flint/sparql.clj
+++ b/src/dev/com/yetanalytics/flint/sparql.clj
@@ -59,7 +59,7 @@
 
   (QueryFactory/create
    "SELECT (COUNT(DISTINCT ?z) AS ?z)
-    WHERE { ?x a <http://foo.org/Thing> }")
+    WHERE { ?x a <htgtp://foo.org/Thing> }")
 
   (println
    (QueryFactory/create

--- a/src/main/com/yetanalytics/flint.cljc
+++ b/src/main/com/yetanalytics/flint.cljc
@@ -1,15 +1,16 @@
 (ns com.yetanalytics.flint
   (:require [clojure.spec.alpha :as s]
-            [com.yetanalytics.flint.spec.query      :as qs]
-            [com.yetanalytics.flint.spec.update     :as us]
-            [com.yetanalytics.flint.format          :as f]
             [com.yetanalytics.flint.format.query]
-            [com.yetanalytics.flint.format.update   :as uf]
-            [com.yetanalytics.flint.error           :as err]
-            [com.yetanalytics.flint.validate        :as v]
-            [com.yetanalytics.flint.validate.bnode  :as vb]
-            [com.yetanalytics.flint.validate.prefix :as vp]
-            [com.yetanalytics.flint.validate.scope  :as vs]))
+            [com.yetanalytics.flint.spec.query         :as qs]
+            [com.yetanalytics.flint.spec.update        :as us]
+            [com.yetanalytics.flint.format             :as f]
+            [com.yetanalytics.flint.format.update      :as uf]
+            [com.yetanalytics.flint.error              :as err]
+            [com.yetanalytics.flint.validate           :as v]
+            [com.yetanalytics.flint.validate.aggregate :as va]
+            [com.yetanalytics.flint.validate.bnode     :as vb]
+            [com.yetanalytics.flint.validate.prefix    :as vp]
+            [com.yetanalytics.flint.validate.scope     :as vs]))
 
 (def xsd-iri-prefix
   "<http://www.w3.org/2001/XMLSchema#>")
@@ -95,6 +96,24 @@
                      (assoc (assert-scope-err-map errs sparql ast)
                             :index index))))))
 
+(defn- assert-aggregates-err-map
+  [agg-errs sparql ast]
+  {:kind   ::invalid-aggregates
+   :errors agg-errs
+   :input  sparql
+   :ast    ast})
+
+(defn- assert-aggregates
+  ([sparql ast nodes-m]
+   (when-some [errs (va/validate-agg-selects nodes-m)]
+     (throw (ex-info (err/aggregate-error-msg errs)
+                     (assert-aggregates-err-map errs sparql ast)))))
+  ([sparql ast nodes-m index]
+   (when-some [errs (va/validate-agg-selects nodes-m)]
+     (throw (ex-info (err/aggregate-error-msg errs)
+                     (assoc (assert-aggregates-err-map errs sparql ast)
+                            :index index))))))
+
 (defn- assert-bnode-err-map
   [{:keys [kind errors prev-bnodes]} sparql ast]
   (cond-> {:kind   kind
@@ -146,6 +165,7 @@
                    (let [nodes-m (v/collect-nodes ast)]
                      (assert-prefixes query ast nodes-m prefix-m)
                      (assert-scoped-vars query ast nodes-m)
+                     (assert-aggregates query ast nodes-m)
                      (assert-bnodes query ast nodes-m)))
         ?xsd-pre (get-xsd-prefix prefix-m)
         opt-m    (cond-> {:pretty? pretty?}
@@ -166,7 +186,8 @@
         _        (when validate?
                    (let [nodes-m (v/collect-nodes ast)]
                      (assert-prefixes update ast nodes-m prefix-m)
-                     (assert-scoped-vars update nodes-m ast)
+                     (assert-scoped-vars update ast nodes-m)
+                     (assert-aggregates update ast nodes-m)
                      (assert-bnodes update ast nodes-m)))
         ?xsd-pre (get-xsd-prefix prefix-m)
         opt-m    (cond-> {:pretty? pretty?}
@@ -191,6 +212,7 @@
                        (let [nodes-m-coll (map v/collect-nodes asts)]
                          (dorun (map assert-prefixes updates asts nodes-m-coll prefix-ms idxs))
                          (dorun (map assert-scoped-vars updates asts nodes-m-coll idxs))
+                         (dorun (map assert-aggregates updates asts nodes-m-coll idxs))
                          (assert-bnodes-coll updates asts nodes-m-coll)))
         xsd-prefixes (map get-xsd-prefix prefix-ms)
         opt-maps     (map (fn [?xsd-pre]

--- a/src/main/com/yetanalytics/flint.cljc
+++ b/src/main/com/yetanalytics/flint.cljc
@@ -116,11 +116,15 @@
 
 (defn- assert-bnode-err-map
   [{:keys [kind errors prev-bnodes]} sparql ast]
-  (cond-> {:kind   kind
-           :errors errors
+  (cond-> {:errors errors
            :input  sparql
            :ast    ast}
-    prev-bnodes (assoc :prev-bnodes prev-bnodes)))
+    (= ::vb/dupe-bnodes-bgp kind)
+    (assoc :kind ::invalid-bnodes-bgp)
+    (= ::vb/dupe-bnodes-update kind)
+    (assoc :kind ::invalid-bnodes-update)
+    prev-bnodes
+    (assoc :prev-bnodes prev-bnodes)))
 
 (defn- assert-bnodes
   [sparql ast nodes-m]

--- a/src/main/com/yetanalytics/flint/error.cljc
+++ b/src/main/com/yetanalytics/flint/error.cljc
@@ -1,8 +1,9 @@
 (ns com.yetanalytics.flint.error
   (:require [clojure.spec.alpha :as s]
             [clojure.string     :as cstr]
-            [com.yetanalytics.flint.validate.bnode :as vb]
-            [com.yetanalytics.flint.validate.scope :as vs]
+            [com.yetanalytics.flint.validate.aggregate :as va]
+            [com.yetanalytics.flint.validate.bnode     :as vb]
+            [com.yetanalytics.flint.validate.scope     :as vs]
             #?@(:clj [[clojure.core :refer [format]]]
                 :cljs [[goog.string :as gstring]
                        [goog.string.format]])))
@@ -27,6 +28,42 @@
     :where
     :group-by :order-by :having :limit :offset :values
     :to :into :with :using})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; String formatting helpers
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- join-str-coll
+  "Join `str-coll` in the form `... x, y and z`."
+  [str-coll]
+  (if (= 1 (count str-coll))
+    (first str-coll)
+    (fmt "%s and %s"
+         (cstr/join ", " (butlast str-coll))
+         (last str-coll))))
+
+(defn- plural-s
+  "Add `s` to the end of `word` if `count` is not 1."
+  [count]
+  (if (= 1 count) "" "s"))
+
+(defn- plural-has
+  "Return `have` if `count` is not 1, `has` otherwise."
+  [count]
+  (if (= 1 count) "has" "have"))
+
+(defn- plural-was
+  "Return `were` if `count` is not 1, `was` otherwise."
+  [count]
+  (if (= 1 count) "was" "were"))
+
+(defn- make-index-str
+  [index]
+  (fmt " at index %d" index))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Spec errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- spec-clause-strs
   [spec-paths]
@@ -71,7 +108,11 @@
   ([spec-ed]
    (spec-error-msg* spec-ed ""))
   ([spec-ed index]
-   (spec-error-msg* spec-ed (fmt " at index %d" index))))
+   (spec-error-msg* spec-ed (make-index-str index))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Prefix errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- prefix-error-msg*
   [prefix-errs index-str]
@@ -80,14 +121,10 @@
         prefix-strs (->> prefix-kws
                          (map name)
                          (map (partial fmt ":%s")))
-        prefix-str  (if (= 1 (count prefix-strs))
-                      (first prefix-strs)
-                      (fmt "%s and %s"
-                           (cstr/join ", " (butlast prefix-strs))
-                           (last prefix-strs)))]
+        prefix-str  (join-str-coll prefix-strs)]
     (fmt "%d IRI%s%s cannot be expanded due to missing prefixes %s!"
          iri-count
-         (if (= 1 iri-count) "" "s")
+         (plural-s iri-count)
          index-str
          prefix-str)))
 
@@ -97,7 +134,11 @@
   ([prefix-errs]
    (prefix-error-msg* prefix-errs ""))
   ([prefix-errs index]
-   (prefix-error-msg* prefix-errs (fmt " at index %d" index))))
+   (prefix-error-msg* prefix-errs (make-index-str index))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Scope errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- scope-error-msg*
   [scope-errs index-str]
@@ -108,18 +149,14 @@
                      (->> ins (map :variable) distinct sort))
         var-count  (->> var-coll count)
         var-strs   (->> var-coll (map name))
-        var-str    (if (= 1 var-count)
-                     (first var-strs)
-                     (fmt "%s and %s"
-                          (cstr/join ", " (butlast var-strs))
-                          (last var-strs)))]
+        var-str    (join-str-coll var-strs)]
     (fmt "%d variable%s%s in %d `expr AS var` clause%s %s %s defined in scope: %s!'"
          var-count
-         (if (= 1 var-count) "" "s")
+         (plural-s var-count)
          index-str
          (count scope-errs)
          (if (= 1 (count scope-errs)) "" "s")
-         (if (= 1 var-count) "was" "were")
+         (plural-was var-count)
          (if (not-empty nots) "not" "already")
          var-str)))
 
@@ -131,6 +168,42 @@
   ([scope-errs index]
    (scope-error-msg* scope-errs (fmt " at index %d" index))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Aggregate errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- aggregate-error-msg*
+  [agg-errs index-str]
+  (let [[wilds errs] (split-with #(= ::va/wildcard-group-by (:kind %))
+                                 agg-errs)]
+    (if (not-empty wilds)
+      (let [wild-count (count wilds)]
+        (fmt "%d SELECT clause%s%s %s both wildcard and GROUP BY!"
+             wild-count
+             (plural-s wild-count)
+             index-str
+             (plural-has wild-count)))
+      (let [var-coll (->> errs (mapcat :variables) distinct sort)
+            var-count (->> var-coll count)
+            var-strs  (->> var-coll (map name))
+            var-str   (join-str-coll var-strs)]
+        (fmt "%d variable%s%s %s illegally used in SELECTs with aggregates: %s!"
+             var-count
+             (plural-s var-count)
+             index-str
+             (plural-was var-count)
+             var-str)))))
+
+(defn aggregate-error-msg
+  ([agg-errs]
+   (aggregate-error-msg* agg-errs ""))
+  ([agg-errs index]
+   (aggregate-error-msg* agg-errs (make-index-str index))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Blank node errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (defn- bnode-error-msg*
   [bnode-err-m index-str]
   (let [bnode-coll  (->> bnode-err-m :errors (map :bnode) distinct)
@@ -141,24 +214,18 @@
                       (fmt "%s and %s"
                            (cstr/join ", " (butlast bnode-strs))
                            (last bnode-strs)))]
-    (case (:kind bnode-err-m)
-      ::vb/dupe-bnodes-update
-      (fmt "%d blank node%s%s %s duplicated from previous updates: %s!"
-           bnode-count
-           (if (= 1 bnode-count) "" "s")
-           index-str
-           (if (= 1 bnode-count) "was" "were")
-           bnode-str)
-      ::vb/dupe-bnodes-bgp
-      (fmt "%d blank node%s%s %s duplicated in multiple BGPs: %s!"
-           bnode-count
-           (if (= 1 bnode-count) "" "s")
-           index-str
-           (if (= 1 bnode-count) "was" "were")
-           bnode-str))))
+    (fmt "%d blank node%s%s %s duplicated %s: %s!"
+         bnode-count
+         (plural-s bnode-count)
+         index-str
+         (plural-was bnode-count)
+         (case (:kind bnode-err-m)
+           ::vb/dupe-bnodes-update "from previous updates"
+           ::vb/dupe-bnodes-bgp    "in multiple BGPs")
+         bnode-str)))
 
 (defn bnode-error-msg
   ([bnode-err-m]
    (bnode-error-msg* bnode-err-m ""))
-  ([bnode-err-m index ]
-   (bnode-error-msg* bnode-err-m (fmt " at index %d" index))))
+  ([bnode-err-m index]
+   (bnode-error-msg* bnode-err-m (make-index-str index))))

--- a/src/main/com/yetanalytics/flint/format.cljc
+++ b/src/main/com/yetanalytics/flint/format.cljc
@@ -1,24 +1,11 @@
 (ns com.yetanalytics.flint.format
   (:require [clojure.string :as cstr]
-            [clojure.walk   :as w]))
+            [clojure.walk   :as w]
+            [com.yetanalytics.flint.util :as u]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Helpers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn ast-node?
-  "Is the node an AST node (created via `s/conform`)?"
-  [x]
-  (and (vector? x)
-       (= 2 (count x))
-       (keyword? (first x))))
-
-(defn dispatch-ast-node
-  "Dispatch on the AST node of the form `[keyword value]`."
-  [ast-node]
-  (if (ast-node? ast-node)
-    (first ast-node)
-    :default))
 
 (defn indent-str
   "Add 4 spaces after each line break (including at the beginning)."
@@ -47,7 +34,7 @@
 
 (defmulti format-ast-node
   "Convert the AST node into a string."
-  (fn [_ x] (dispatch-ast-node x)))
+  (fn [_ x] (if-some [k (u/get-keyword x)] k :default)))
 
 (defmethod format-ast-node :default [_ ast-node] ast-node)
 

--- a/src/main/com/yetanalytics/flint/spec/expr.cljc
+++ b/src/main/com/yetanalytics/flint/spec/expr.cljc
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.flint.spec.expr
   (:require [clojure.spec.alpha :as s]
+            [clojure.set :as cset]
             [com.yetanalytics.flint.spec.axiom :as ax])
   #?(:cljs (:require-macros
             [com.yetanalytics.flint.spec.expr :refer [keyword-args]])))
@@ -67,6 +68,9 @@
 
 (def unary-agg-sep-ops
   #{'group-concat})
+
+(def aggregate-ops
+  (cset/union unary-agg-ops unary-agg-wild-ops unary-agg-sep-ops))
 
 (def unary-var-ops
   #{'bound})

--- a/src/main/com/yetanalytics/flint/spec/modifier.cljc
+++ b/src/main/com/yetanalytics/flint/spec/modifier.cljc
@@ -4,17 +4,17 @@
             [com.yetanalytics.flint.spec.expr  :as es]))
 
 (s/def ::group-by
-  (s/coll-of (s/or :mod/expr        ::es/expr
-                   :ax/var          ax/variable?
+  (s/coll-of (s/or :ax/var          ax/variable?
+                   :mod/expr        ::es/expr
                    :mod/expr-as-var ::es/expr-as-var)
              :min-count 1
              :kind vector?))
 
 (s/def ::order-by
-  (s/coll-of (s/or :mod/asc-desc (s/& (s/cat :mod/op #{'asc 'desc}
+  (s/coll-of (s/or :ax/var       ax/variable?
+                   :mod/asc-desc (s/& (s/cat :mod/op #{'asc 'desc}
                                              :mod/expr ::es/agg-expr)
                                       (s/conformer #(into [] %)))
-                   :ax/var       ax/variable?
                    :mod/expr     ::es/agg-expr)
              :min-count 1
              :kind vector?))

--- a/src/main/com/yetanalytics/flint/spec/select.cljc
+++ b/src/main/com/yetanalytics/flint/spec/select.cljc
@@ -30,11 +30,3 @@
 (s/def ::select select-spec)
 (s/def ::select-distinct select-spec)
 (s/def ::select-reduced select-spec)
-
-(comment
-  (no-duplicate-vars?
-   '[[:ax/var ?x]
-     [:ax/var ?x]
-     [:select/expr-as-var [:expr/as-var
-                           [[:expr/terminal [:ax/num-lit 2]]
-                            [:ax/var ?z]]]]]))

--- a/src/main/com/yetanalytics/flint/spec/select.cljc
+++ b/src/main/com/yetanalytics/flint/spec/select.cljc
@@ -3,13 +3,38 @@
             [com.yetanalytics.flint.spec.axiom :as ax]
             [com.yetanalytics.flint.spec.expr  :as es]))
 
+(defn- no-duplicate-vars?
+  [var-or-exprs]
+  (boolean (reduce (fn [seen [k x]]
+                     (case k
+                       :ax/var
+                       (if (contains? seen x)
+                         (reduced false)
+                         (conj seen x))
+                       :select/expr-as-var
+                       (let [v (-> x second second second)]
+                         (if (contains? seen v)
+                           (reduced false)
+                           (conj seen v)))))
+                   #{}
+                   var-or-exprs)))
+
 (def select-spec
   (s/or :select/var-or-exprs
-        (s/* (s/alt :ax/var ax/variable?
-                    :select/expr-as-var ::es/agg-expr-as-var))
+        (s/and (s/* (s/alt :ax/var ax/variable?
+                           :select/expr-as-var ::es/agg-expr-as-var))
+               no-duplicate-vars?)
         :ax/wildcard
         ax/wildcard?))
 
 (s/def ::select select-spec)
 (s/def ::select-distinct select-spec)
 (s/def ::select-reduced select-spec)
+
+(comment
+  (no-duplicate-vars?
+   '[[:ax/var ?x]
+     [:ax/var ?x]
+     [:select/expr-as-var [:expr/as-var
+                           [[:expr/terminal [:ax/num-lit 2]]
+                            [:ax/var ?z]]]]]))

--- a/src/main/com/yetanalytics/flint/util.cljc
+++ b/src/main/com/yetanalytics/flint/util.cljc
@@ -1,0 +1,17 @@
+(ns com.yetanalytics.flint.util)
+
+(defn get-keyword
+  "If `x` is a `[:keyword value]` pair, return the keyword; otherwise
+   return `nil`."
+  [x]
+  (when (vector? x)
+    (let [fst (first x)]
+      (when (keyword? fst)
+        fst))))
+
+(defn get-kv-pair
+  "Given `coll` of `[:keyword value]` pairs, return the pair
+   with keyword `k`. In other words, just like `get` for
+   associative collections."
+  [coll k]
+  (some #(when (-> % first (= k)) %) coll))

--- a/src/main/com/yetanalytics/flint/validate.cljc
+++ b/src/main/com/yetanalytics/flint/validate.cljc
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.flint.validate
   (:require [clojure.zip :as zip]
-            [com.yetanalytics.flint.spec.expr :as es]))
+            [com.yetanalytics.flint.spec.expr :as es]
+            [com.yetanalytics.flint.util :as u]))
 
 (def axiom-keys
   #{:ax/iri :ax/prefix-iri :ax/var :ax/bnode :ax/wildcard :ax/rdf-type :ax/nil
@@ -8,16 +9,9 @@
     ;; Not actually axioms but still counted as AST terminals
     :distinct? :separator})
 
-(defn- get-keyword
-  [x]
-  (when (vector? x)
-    (let [fst (first x)]
-      (when (keyword? fst)
-        fst))))
-
 (defn- ast-branch?
   [x]
-  (when-some [k (get-keyword x)]
+  (when-some [k (u/get-keyword x)]
     (not (axiom-keys k))))
 
 (defn- ast-children
@@ -56,7 +50,7 @@
   (loop [loc loc]
     (when-not (nil? loc) ; Reached the top w/o finding a SELECT
       (let [ast-node (zip/node loc)]
-        (if (#{:query/select :where-sub/select} (get-keyword ast-node))
+        (if (#{:query/select :where-sub/select} (u/get-keyword ast-node))
           loc
           (recur (zip/up loc)))))))
 
@@ -66,7 +60,7 @@
          node-m {}]
     (if-not (zip/end? loc)
       (let [ast-node (zip/node loc)]
-        (if-some [k (get-keyword ast-node)]
+        (if-some [k (u/get-keyword ast-node)]
           (cond
             ;; Prefixes, blank nodes, and BIND clauses
             (node-keys k)

--- a/src/main/com/yetanalytics/flint/validate/aggregate.cljc
+++ b/src/main/com/yetanalytics/flint/validate/aggregate.cljc
@@ -1,0 +1,89 @@
+(ns com.yetanalytics.flint.validate.aggregate
+  (:require [com.yetanalytics.flint.spec.expr :as es]))
+
+;; In a query level which uses aggregates, only expressions consisting of
+;; aggregates and constants may be projected, with one exception.
+;; When GROUP BY is given with one or more simple expressions consisting of
+;; just a variable, those variables may be projected from the level.
+
+;; GOOD:
+;;   SELECT (2 AS ?two) WHER { ?x ?y ?z }
+;;   SELECT (SUM(?x) AS ?sum) WHERE { ?x ?y ?z }
+;;   SELECT ?x WHERE { ?x ?y ?z } GROUP BY ?x
+
+;; BAD:
+;;   SELECT (AVG(?x)) AS ?avg) ((?x + ?y) AS ?sum) WHERE { ?x ?y ?z }
+;;   SELECT ?y ?z WHERE { ?x ?y ?z } GROUP BY ?x
+
+(defmulti group-by-projected-vars (fn [[k _]] k))
+
+(defmethod group-by-projected-vars :group-by [[_ group-by-coll]]
+  (->> group-by-coll
+       (map group-by-projected-vars)
+       (filter some?)))
+
+(defmethod group-by-projected-vars :mod/expr [_] nil)
+
+(defmethod group-by-projected-vars :ax/var [[_ v]] v)
+
+(defmethod group-by-projected-vars :mod/expr-as-var [[_ expr-as-var]]
+  (-> expr-as-var second second second))
+
+(defmulti invalid-agg-expr-vars (fn [_ [k _]] k))
+
+(defmethod invalid-agg-expr-vars :default [_] [])
+
+(defmethod invalid-agg-expr-vars :expr/branch [valid-vars [_ [[_ op] [_ args]]]]
+  (if (es/aggregate-ops op)
+    []
+    (mapcat (partial invalid-agg-expr-vars valid-vars) args)))
+
+(defmethod invalid-agg-expr-vars :expr/terminal [valid-vars [_ x]]
+  (invalid-agg-expr-vars valid-vars x))
+
+(defmethod invalid-agg-expr-vars :ax/var [valid-vars [_ v]]
+  (if-not (valid-vars v) [v] []))
+
+(defn- validate-agg-select-clause
+  [group-by-vars sel-clause]
+  (let [err-or-valid
+        (reduce (fn [valid-vars [k x]]
+                  (case k
+                    :ax/var
+                    (if (valid-vars x)
+                      valid-vars
+                      (reduced {:errors [x]}))
+                    :select/expr-as-var
+                    (let [[_expr-as-var-kw [expr [_v-kw v]]] x]
+                      (if-some [bad-evars (not-empty (invalid-agg-expr-vars valid-vars expr))]
+                        (reduced {:errors bad-evars})
+                        (conj valid-vars v)))))
+                group-by-vars
+                sel-clause)]
+    (if-some [bad-vars (:errors err-or-valid)]
+      bad-vars
+      nil)))
+
+(defn validate-agg-select
+  [select loc]
+  (let [select-cls  (some #(when (= :select (first %)) (second %)) (second select))
+        ?group-by   (some #(when (= :group-by (first %)) (second %)) (second select))
+        group-by-vs (if ?group-by
+                      (->> ?group-by
+                           (map group-by-projected-vars)
+                           (filter some?)
+                           set)
+                      #{})]
+    (if (= :ax/wildcard (first select-cls))
+      {:kind ::wildcard-group-by
+       :loc  loc}
+      (when-some [bad-vars (validate-agg-select-clause group-by-vs (second select-cls))]
+        {:kind      ::invalid-aggregate-var
+         :variables bad-vars
+         :loc       loc}))))
+
+(defn validate-agg-selects
+  [node-m]
+  (->> (:agg/select node-m)
+       (map (fn [[sel loc]] (validate-agg-select sel loc)))
+       (filter some?)))

--- a/src/main/com/yetanalytics/flint/validate/aggregate.cljc
+++ b/src/main/com/yetanalytics/flint/validate/aggregate.cljc
@@ -36,7 +36,7 @@
 
 (defmulti invalid-agg-expr-vars (fn [_ [k _]] k))
 
-(defmethod invalid-agg-expr-vars :default [_] [])
+(defmethod invalid-agg-expr-vars :default [_ _] [])
 
 (defmethod invalid-agg-expr-vars :expr/branch [valid-vars [_ [op-kv args-kv]]]
   (let [[_ op] op-kv
@@ -103,4 +103,5 @@
   [node-m]
   (->> (:agg/select node-m)
        (map validate-agg-select)
-       (filter some?)))
+       (filter some?)
+       not-empty))

--- a/src/main/com/yetanalytics/flint/validate/aggregate.cljc
+++ b/src/main/com/yetanalytics/flint/validate/aggregate.cljc
@@ -1,5 +1,6 @@
 (ns com.yetanalytics.flint.validate.aggregate
-  (:require [com.yetanalytics.flint.validate.variable :as vv]
+  (:require [clojure.zip :as zip]
+            [com.yetanalytics.flint.validate.variable :as vv]
             [com.yetanalytics.flint.util              :as u]))
 
 ;; In a query level which uses aggregates, only expressions consisting of
@@ -55,11 +56,11 @@
         [sel-k sel-v]  select-cls]
     (if (= :ax/wildcard sel-k)
       {:kind ::wildcard-group-by
-       :loc  loc}
+       :path (->> loc zip/path (mapv first))}
       (when-some [bad-vars (validate-agg-select-clause group-by-vs sel-v)]
         {:kind      ::invalid-aggregate-var
          :variables bad-vars
-         :loc       loc}))))
+         :path      (->> loc zip/path (mapv first))}))))
 
 (defn validate-agg-selects
   "Validate, given `node-m` that contains a map from `SELECT` AST nodes to

--- a/src/main/com/yetanalytics/flint/validate/aggregate.cljc
+++ b/src/main/com/yetanalytics/flint/validate/aggregate.cljc
@@ -34,7 +34,8 @@
 (defmethod invalid-agg-expr-vars :default [_] [])
 
 (defmethod invalid-agg-expr-vars :expr/branch [valid-vars [_ [[_ op] [_ args]]]]
-  (if (es/aggregate-ops op)
+  (if (or (es/aggregate-ops op)
+          (not (symbol? op)))
     []
     (mapcat (partial invalid-agg-expr-vars valid-vars) args)))
 

--- a/src/main/com/yetanalytics/flint/validate/aggregate.cljc
+++ b/src/main/com/yetanalytics/flint/validate/aggregate.cljc
@@ -62,6 +62,10 @@
          :loc       loc}))))
 
 (defn validate-agg-selects
+  "Validate, given `node-m` that contains a map from `SELECT` AST nodes to
+   their zipper locs, that any SELECT that includes aggregates are valid
+   according to the SPARQL spec. Returns `nil` if valid, a coll of error
+   maps otherwise."
   [node-m]
   (->> (:agg/select node-m)
        (map validate-agg-select)

--- a/src/main/com/yetanalytics/flint/validate/scope.cljc
+++ b/src/main/com/yetanalytics/flint/validate/scope.cljc
@@ -4,31 +4,6 @@
             [com.yetanalytics.flint.util              :as u]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Computing variables and var scopes
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defmulti get-expr-vars
-  (fn [x] (if (and (vector? x) (= 2 (count x)) (keyword? (first x)))
-            (first x)
-            :default)))
-
-(defmethod get-expr-vars :default [_] nil)
-
-(defmethod get-expr-vars :ax/var [[_ v]] [v])
-
-(defmethod get-expr-vars :expr/as-var [[_ [expr _v]]]
-  (get-expr-vars expr))
-
-(defmethod get-expr-vars :expr/branch [[_ expr]]
-  (mapcat get-expr-vars expr))
-
-(defmethod get-expr-vars :expr/args [[_ args]]
-  (mapcat get-expr-vars args))
-
-(defmethod get-expr-vars :expr/terminal [[_ expr-term]]
-  (get-expr-vars expr-term))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Validation on AST zipper
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -59,7 +34,7 @@
   "Validate `SELECT ... (expr AS var) ..."
   [[_expr-as-var-k [expr v-kv]] loc]
   (let [[_ bind-var] v-kv
-        expr-vars    (get-expr-vars expr)
+        expr-vars    (vv/get-expr-vars expr)
         prev-elems   (zip/lefts loc)
         sel-query    (->> loc
                           zip/up ; :select/var-or-exprs

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -1,0 +1,183 @@
+(ns com.yetanalytics.flint.validate.variable
+  (:require [com.yetanalytics.flint.util :as u]
+            [com.yetanalytics.flint.spec.expr :as es]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; SELECT aggregate variables
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmulti invalid-agg-expr-vars (fn [_ [k _]] k))
+
+(defmethod invalid-agg-expr-vars :default [_ _] [])
+
+(defmethod invalid-agg-expr-vars :expr/branch [valid-vars [_ [op-kv args-kv]]]
+  (let [[_ op] op-kv
+        [_ args] args-kv]
+    (if (or (es/aggregate-ops op)
+            (not (symbol? op)))
+      []
+      (mapcat (partial invalid-agg-expr-vars valid-vars) args))))
+
+(defmethod invalid-agg-expr-vars :expr/terminal [valid-vars [_ x]]
+  (invalid-agg-expr-vars valid-vars x))
+
+(defmethod invalid-agg-expr-vars :ax/var [valid-vars [_ v]]
+  (if-not (valid-vars v) [v] []))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; GROUP BY projection variables
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmulti group-by-projected-vars (fn [[k _]] k))
+
+(defmethod group-by-projected-vars :group-by [[_ group-by-coll]]
+  (->> group-by-coll
+       (map group-by-projected-vars)
+       (filter some?)))
+
+(defmethod group-by-projected-vars :mod/expr [_] nil)
+
+(defmethod group-by-projected-vars :ax/var [[_ v]] v)
+
+(defmethod group-by-projected-vars :mod/expr-as-var [[_ expr-as-var]]
+  (-> expr-as-var second second second))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Expression variables
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmulti get-expr-vars
+  (fn [x] (if (and (vector? x) (= 2 (count x)) (keyword? (first x)))
+            (first x)
+            :default)))
+
+(defmethod get-expr-vars :default [_] nil)
+
+(defmethod get-expr-vars :ax/var [[_ v]] [v])
+
+(defmethod get-expr-vars :expr/as-var [[_ [expr _v]]]
+  (get-expr-vars expr))
+
+(defmethod get-expr-vars :expr/branch [[_ expr]]
+  (mapcat get-expr-vars expr))
+
+(defmethod get-expr-vars :expr/args [[_ args]]
+  (mapcat get-expr-vars args))
+
+(defmethod get-expr-vars :expr/terminal [[_ expr-term]]
+  (get-expr-vars expr-term))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Variable Scopes
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defmulti get-scope-vars
+  "Return a coll of all variables in the scope of the AST branch."
+  (fn [x] (if (and (vector? x) (= 2 (count x)) (keyword? (first x)))
+            (first x)
+            :default)))
+
+(defmethod get-scope-vars :default [_] nil)
+
+(defmethod get-scope-vars :ax/var [[_ v]] [v])
+
+(defmethod get-scope-vars :expr/as-var [[_ [_expr v]]]
+  (get-scope-vars v))
+
+;; SELECT in-scope vars
+
+(defmethod get-scope-vars :select/expr-as-var [[_ expr-as-var]]
+  (get-scope-vars expr-as-var))
+
+;; WHERE in-scope vars
+
+(defmethod get-scope-vars :where [[_ vs]]
+  (get-scope-vars vs))
+
+;; Basic Graph Pattern
+
+(defmethod get-scope-vars :triple/vec [[_ spo]]
+  (mapcat get-scope-vars spo))
+
+(defmethod get-scope-vars :triple/o [[_ o]]
+  (mapcat get-scope-vars o))
+
+(defmethod get-scope-vars :triple/po [[_ po]]
+  (reduce-kv (fn [acc p o] (apply concat
+                                  acc
+                                  (get-scope-vars p)
+                                  (map get-scope-vars o)))
+             []
+             po))
+
+(defmethod get-scope-vars :triple/spo [[_ spo]]
+  (reduce-kv (fn [acc s po] (apply concat
+                                   acc
+                                   (get-scope-vars s)
+                                   (map get-scope-vars po)))
+             []
+             spo))
+
+(defmethod get-scope-vars :triple/nform [[_ nform]]
+  (get-scope-vars nform))
+
+;; Path
+
+(defmethod get-scope-vars :triple/path [[_ p]]
+  (get-scope-vars p))
+
+(defmethod get-scope-vars :path/branch [[_ [_op [_k paths]]]]
+  (mapcat get-scope-vars paths))
+
+(defmethod get-scope-vars :path/terminal [[_ v]]
+  (get-scope-vars v))
+
+;; Group
+
+(defmethod get-scope-vars :where/recurse [[_ vs]]
+  (get-scope-vars vs))
+
+(defmethod get-scope-vars :select/expr-as-var [[_ ev]]
+  (get-scope-vars ev))
+
+(defmethod get-scope-vars :where-sub/select [[_ s]]
+  (let [[_ select] (u/get-kv-pair s :select)
+        where      (u/get-kv-pair s :where)
+        ?group-by  (u/get-kv-pair s :group-by)]
+    (case (first select)
+      :ax/wildcard
+      (cond-> (get-scope-vars where)
+        ?group-by
+        (mapcat (group-by-projected-vars group-by)))
+      :select/var-or-exprs
+      (mapcat get-scope-vars (second select)))))
+
+(defmethod get-scope-vars :where-sub/where [[_ vs]]
+  (mapcat get-scope-vars vs))
+
+(defmethod get-scope-vars :where-sub/empty [_] [])
+
+;; WHERE modifiers
+
+(defmethod get-scope-vars :where/union [[_ vs]]
+  (mapcat get-scope-vars vs))
+
+(defmethod get-scope-vars :where/optional [[_ vs]]
+  (get-scope-vars vs))
+
+(defmethod get-scope-vars :where/graph [[_ [term vs]]]
+  (concat (get-scope-vars term) (get-scope-vars vs)))
+
+(defmethod get-scope-vars :where/service [[_ [term vs]]]
+  (concat (get-scope-vars term) (get-scope-vars vs)))
+
+(defmethod get-scope-vars :where/service-silent [[_ [term vs]]]
+  (concat (get-scope-vars term) (get-scope-vars vs)))
+
+(defmethod get-scope-vars :where/bind [[_ vs]]
+  (get-scope-vars vs))
+
+(defmethod get-scope-vars :where/values [[_ [_ values]]]
+  (mapcat get-scope-vars (first values)))
+

--- a/src/test/com/yetanalytics/flint/error_test.cljc
+++ b/src/test/com/yetanalytics/flint/error_test.cljc
@@ -150,6 +150,13 @@
                 v/collect-nodes
                 vs/validate-scoped-vars
                 err/scope-error-msg)))
+    (is (= "2 variables in 1 `expr AS var` clause was not defined in scope: ?u and ?v!'"
+           (->> '{:select [[(+ ?u ?v) ?x]]
+                  :where  [[?x ?y ?z]]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                vs/validate-scoped-vars
+                err/scope-error-msg)))
     (is (= "2 variables in 2 `expr AS var` clauses were already defined in scope: ?x and ?y!'"
            (->> '{:select [[2 ?y]]
                   :where  [[?x ?y ?z]

--- a/src/test/com/yetanalytics/flint/error_test.cljc
+++ b/src/test/com/yetanalytics/flint/error_test.cljc
@@ -150,7 +150,7 @@
                 v/collect-nodes
                 vs/validate-scoped-vars
                 err/scope-error-msg)))
-    (is (= "2 variables in 1 `expr AS var` clause was not defined in scope: ?u and ?v!'"
+    (is (= "2 variables in 1 `expr AS var` clause were not defined in scope: ?u and ?v!'"
            (->> '{:select [[(+ ?u ?v) ?x]]
                   :where  [[?x ?y ?z]]}
                 (s/conform qs/query-spec)

--- a/src/test/com/yetanalytics/flint/error_test.cljc
+++ b/src/test/com/yetanalytics/flint/error_test.cljc
@@ -186,9 +186,11 @@
                 v/collect-nodes
                 va/validate-agg-selects
                 err/aggregate-error-msg)))
-    (is (= "1 SELECT clause has both wildcard and GROUP BY!"
+    (is (= "2 SELECT clauses have both wildcard and GROUP BY!"
            (->> '{:select   :*
-                  :where    [[?x ?y ?z]]
+                  :where    {:select   :*
+                             :where    [[?x ?y ?z]]
+                             :group-by [?x]}
                   :group-by [?x]}
                 (s/conform qs/query-spec)
                 v/collect-nodes

--- a/src/test/com/yetanalytics/flint/spec/modifier_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/modifier_test.cljc
@@ -5,7 +5,7 @@
 
 (deftest conform-modifier-test
   (testing "Conforming solution modifiers"
-    (is (= [[:mod/expr [:expr/terminal [:ax/var '?foo]]]]
+    (is (= [[:ax/var '?foo]]
            (s/conform ::ms/group-by ['?foo])))
     (is (= '[[:mod/expr-as-var
               [:expr/as-var
@@ -14,6 +14,8 @@
                                             [:expr/terminal [:ax/num-lit 2]])]]]
                 [:ax/var ?foo]]]]]
            (s/conform ::ms/group-by ['[(+ 2 2) ?foo]])))
+    (is (= '[[:ax/var ?foo]]
+           (s/conform ::ms/order-by '[?foo])))
     (is (= '[[:mod/asc-desc
               [[:mod/op asc]
                [:mod/expr [:expr/terminal [:ax/var ?bar]]]]]]

--- a/src/test/com/yetanalytics/flint/spec/select_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/select_test.cljc
@@ -1,0 +1,23 @@
+(ns com.yetanalytics.flint.spec.select-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.spec.alpha :as s]
+            [com.yetanalytics.flint.spec.select :as ss]))
+
+(deftest conform-select-test
+  (testing "Conform SELECT clauses"
+    (is (= [:ax/wildcard '*]
+           (s/conform ss/select-spec '*)))
+    (is (= '[:select/var-or-exprs
+             [[:ax/var ?x]
+              [:ax/var ?y]
+              [:select/expr-as-var [:expr/as-var
+                                    [[:expr/terminal [:ax/num-lit 2]]
+                                     [:ax/var ?z]]]]]]
+           (s/conform ss/select-spec '[?x ?y [2 ?z]])))))
+
+(deftest invalid-select-test
+  (testing "Invalid SELECT clauses"
+    (is (not (s/valid? ss/select-spec '[?x ?x])))
+    (is (not (s/valid? ss/select-spec '[?x ?y [2 ?y]])))
+    (is (not (s/valid? ss/select-spec '[?x [2 ?y] ?y])))
+    (is (not (s/valid? ss/select-spec '[[2 ?y] [3 ?y]])))))

--- a/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
@@ -102,6 +102,11 @@
               (s/conform qs/query-spec)
               v/collect-nodes
               va/validate-agg-selects)))
+    (is (nil? ; ORDER BY and HAVING do not factor into any of this
+         (->> '{:select [[(sum ?x) ?sum]]
+                :where  [[?x ?y ?z]]
+                :order-by [(sum ?x) ?y]
+                :having   [(sum ?x) (+ ?y ?y)]})))
     (is (nil?
          ;; Taken from select-agg-3.edn
          (->> '{:select   [?g [(avg ?p) ?avg] [(/ (+ (min ?p) (max ?p)) 2) ?c]]

--- a/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
@@ -127,6 +127,15 @@
                 va/validate-agg-selects
                 (map #(dissoc % :loc)))))
     (is (= [{:kind ::va/invalid-aggregate-var
+             :variables ['?y '?z]}]
+           (->> '{:select   [?y ?z]
+                  :where    [[?x ?y ?z]]
+                  :group-by [?x]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects
+                (map #(dissoc % :loc)))))
+    (is (= [{:kind ::va/invalid-aggregate-var
              :variables ['?z]}]
            (->> '{:select [?x]
                   :where  {:select   [?z]

--- a/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
@@ -3,46 +3,47 @@
             [clojure.spec.alpha :as s]
             [com.yetanalytics.flint.validate           :as v]
             [com.yetanalytics.flint.validate.aggregate :as va]
+            [com.yetanalytics.flint.validate.variable  :as vv]
             [com.yetanalytics.flint.spec.query         :as qs]))
 
 (deftest helper-test
   (testing "helper multimethods"
     (testing "to find GROUP BY projected vars"
       (is (= []
-             (va/group-by-projected-vars
+             (vv/group-by-projected-vars
               '[:group-by
                 [[:mod/expr [:expr/terminal [:ax/var ?x]]]]])))
       (is (= '[?x ?y ?z]
-             (va/group-by-projected-vars
+             (vv/group-by-projected-vars
               '[:group-by
                 [[:ax/var ?x] [:ax/var ?y] [:ax/var ?z]]])))
       (is (= '[?y]
-             (va/group-by-projected-vars
+             (vv/group-by-projected-vars
               '[:group-by
                 [[:mod/expr-as-var
                   [:expr/as-var [[:expr/terminal [:ax/var ?x]]
                                  [:ax/var ?y]]]]]]))))
     (testing "to find invalid vars in aggregate SELECT exprs"
       (is (= '[?x]
-             (va/invalid-agg-expr-vars
+             (vv/invalid-agg-expr-vars
               #{}
               '[:expr/terminal [:ax/var ?x]])))
       (is (= []
-             (va/invalid-agg-expr-vars
+             (vv/invalid-agg-expr-vars
               #{'?x}
               '[:expr/terminal [:ax/var ?x]])))
       (is (= ['?x]
-             (va/invalid-agg-expr-vars
+             (vv/invalid-agg-expr-vars
               #{}
               '[:expr/branch [[:expr/op str]
                               [:expr/args [[:expr/terminal [:ax/var ?x]]]]]])))
       (is (= []
-             (va/invalid-agg-expr-vars
+             (vv/invalid-agg-expr-vars
               #{}
               '[:expr/branch [[:expr/op count]
                               [:expr/args [[:expr/terminal [:ax/var ?x]]]]]])))
       (is (= []
-             (va/invalid-agg-expr-vars
+             (vv/invalid-agg-expr-vars
               #{'?x}
               '[:expr/branch [[:expr/op str]
                               [:expr/args [[:expr/terminal [:ax/var ?x]]]]]]))))))

--- a/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
@@ -117,7 +117,7 @@
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 va/validate-agg-selects
-                (map #(dissoc % :loc)))))
+                (map #(dissoc % :path)))))
     (is (= [{:kind ::va/invalid-aggregate-var
              :variables ['?z]}]
            (->> '{:select [[("<http://custom.agg>" ?x) ?sum] [(str ?z) ?str]]
@@ -125,7 +125,7 @@
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 va/validate-agg-selects
-                (map #(dissoc % :loc)))))
+                (map #(dissoc % :path)))))
     (is (= [{:kind ::va/invalid-aggregate-var
              :variables ['?z]}]
            (->> '{:select   [?z]
@@ -134,7 +134,7 @@
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 va/validate-agg-selects
-                (map #(dissoc % :loc)))))
+                (map #(dissoc % :path)))))
     (is (= [{:kind ::va/invalid-aggregate-var
              :variables ['?y '?z]}]
            (->> '{:select   [?y ?z]
@@ -143,7 +143,7 @@
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 va/validate-agg-selects
-                (map #(dissoc % :loc)))))
+                (map #(dissoc % :path)))))
     (is (= [{:kind ::va/invalid-aggregate-var
              :variables ['?z]}]
            (->> '{:select [?x]
@@ -153,7 +153,7 @@
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 va/validate-agg-selects
-                (map #(dissoc % :loc)))))
+                (map #(dissoc % :path)))))
     (is (= [{:kind ::va/wildcard-group-by}]
            (->> '{:select   :*
                   :where    [[?x ?y ?z]]
@@ -161,7 +161,7 @@
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 va/validate-agg-selects
-                (map #(dissoc % :loc)))))
+                (map #(dissoc % :path)))))
     (is (= [{:kind ::va/wildcard-group-by}]
            (->> '{:select :*
                   :where  {:select   :*
@@ -170,4 +170,4 @@
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 va/validate-agg-selects
-                (map #(dissoc % :loc)))))))
+                (map #(dissoc % :path)))))))

--- a/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
@@ -1,0 +1,114 @@
+(ns com.yetanalytics.flint.validate.aggregate-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.spec.alpha :as s]
+            [com.yetanalytics.flint.validate           :as v]
+            [com.yetanalytics.flint.validate.aggregate :as va]
+            [com.yetanalytics.flint.spec.query         :as qs]))
+
+(deftest helper-test
+  (testing "helper multimethods"
+    (testing "to find GROUP BY projected vars"
+      (is (= []
+             (va/group-by-projected-vars
+              '[:group-by
+                [[:mod/expr [:expr/terminal [:ax/var ?x]]]]])))
+      (is (= '[?x ?y ?z]
+             (va/group-by-projected-vars
+              '[:group-by
+                [[:ax/var ?x] [:ax/var ?y] [:ax/var ?z]]])))
+      (is (= '[?y]
+             (va/group-by-projected-vars
+              '[:group-by
+                [[:mod/expr-as-var
+                  [:expr/as-var [[:expr/terminal [:ax/var ?x]]
+                                 [:ax/var ?y]]]]]]))))
+    (testing "to find invalid vars in aggregate SELECT exprs"
+      (is (= '[?x]
+             (va/invalid-agg-expr-vars
+              #{}
+              '[:expr/terminal [:ax/var ?x]])))
+      (is (= []
+             (va/invalid-agg-expr-vars
+              #{'?x}
+              '[:expr/terminal [:ax/var ?x]])))
+      (is (= ['?x]
+             (va/invalid-agg-expr-vars
+              #{}
+              '[:expr/branch [[:expr/op str]
+                              [:expr/args [[:expr/terminal [:ax/var ?x]]]]]])))
+      (is (= []
+             (va/invalid-agg-expr-vars
+              #{}
+              '[:expr/branch [[:expr/op count]
+                              [:expr/args [[:expr/terminal [:ax/var ?x]]]]]])))
+      (is (= []
+             (va/invalid-agg-expr-vars
+              #{'?x}
+              '[:expr/branch [[:expr/op str]
+                              [:expr/args [[:expr/terminal [:ax/var ?x]]]]]]))))))
+
+(deftest aggregates-validation-test
+  (testing "Validating SELECTs with aggregates"
+    (is (= []
+           (->> '{:select [[2 ?sum]]
+                  :where  [[?x ?y ?z]]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects)))
+    (is (= []
+           (->> '{:select [[(str ?z) ?str]]
+                  :where  [[?x ?y ?z]]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects)))
+    (is (= []
+           (->> '{:select [[(sum ?x) ?sum]]
+                  :where  [[?x ?y ?z]]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects)))
+    (is (= []
+           (->> '{:select [[(sum ?x :distinct? true) ?sum]]
+                  :where  [[?x ?y ?z]]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects)))
+    (is (= []
+           (->> '{:select   [?x]
+                  :where    [[?x ?y ?z]]
+                  :group-by [?x]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects)))
+    (is (= []
+           (->> '{:select   [[(sum ?x) ?x2] [(str ?x2) ?x3]]
+                  :where    [[?x ?y ?z]]
+                  :group-by [?x]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects)))
+    (is (= [{:kind ::va/invalid-aggregate-var
+             :variables ['?z]}]
+           (->> '{:select [[(sum ?x) ?sum] [(str ?z) ?str]]
+                  :where  [[?x ?y ?z]]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects
+                (map #(dissoc % :loc)))))
+    (is (= [{:kind ::va/invalid-aggregate-var
+             :variables ['?z]}]
+           (->> '{:select   [?z]
+                  :where    [[?x ?y ?z]]
+                  :group-by [?x [2 ?y]]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects
+                (map #(dissoc % :loc)))))
+    (is (= [{:kind ::va/wildcard-group-by}]
+           (->> '{:select   :*
+                  :where    [[?x ?y ?z]]
+                  :group-by [?x]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                va/validate-agg-selects
+                (map #(dissoc % :loc)))))))

--- a/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
@@ -49,58 +49,66 @@
 
 (deftest aggregates-validation-test
   (testing "Validating SELECTs with aggregates"
-    (is (= []
-           (->> '{:select [[2 ?sum]]
-                  :where  [[?x ?y ?z]]}
-                (s/conform qs/query-spec)
-                v/collect-nodes
-                va/validate-agg-selects)))
-    (is (= []
-           (->> '{:select [[(str ?z) ?str]]
-                  :where  [[?x ?y ?z]]}
-                (s/conform qs/query-spec)
-                v/collect-nodes
-                va/validate-agg-selects)))
-    (is (= []
-           (->> '{:select [[(sum ?x) ?sum]]
-                  :where  [[?x ?y ?z]]}
-                (s/conform qs/query-spec)
-                v/collect-nodes
-                va/validate-agg-selects)))
-    (is (= []
-           (->> '{:select [[(sum ?x :distinct? true) ?sum]]
-                  :where  [[?x ?y ?z]]}
-                (s/conform qs/query-spec)
-                v/collect-nodes
-                va/validate-agg-selects)))
+    (is (nil?
+         (->> '{:select [[2 ?sum]]
+                :where  [[?x ?y ?z]]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
+    (is (nil?
+         (->> '{:select [[(str ?z) ?str]]
+                :where  [[?x ?y ?z]]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
+    (is (nil?
+         (->> '{:select [[(sum ?x) ?sum]]
+                :where  [[?x ?y ?z]]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
+    (is (nil?
+         (->> '{:select [[(sum ?x :distinct? true) ?sum]]
+                :where  [[?x ?y ?z]]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
     ;; All custom fns in SELECT queries are treated as custom aggregates
-    (is (= []
-           (->> '{:select [[("<http://custom.agg>" ?x) ?sum]]
-                  :where  [[?x ?y ?z]]}
-                (s/conform qs/query-spec)
-                v/collect-nodes
-                va/validate-agg-selects)))
-    (is (= []
-           (->> '{:select   [?x]
-                  :where    [[?x ?y ?z]]
-                  :group-by [?x]}
-                (s/conform qs/query-spec)
-                v/collect-nodes
-                va/validate-agg-selects)))
-    (is (= []
-           (->> '{:select   [[(sum ?x) ?x2] [(str ?x2) ?x3]]
-                  :where    [[?x ?y ?z]]
-                  :group-by [?x]}
-                (s/conform qs/query-spec)
-                v/collect-nodes
-                va/validate-agg-selects)))
-    (is (= []
-           (->> '{:select   [?x]
-                  :where    [{:select [[(sum ?y) ?sum]]
-                              :where [?x ?y ?z]}]}
-                (s/conform qs/query-spec)
-                v/collect-nodes
-                va/validate-agg-selects)))
+    (is (nil?
+         (->> '{:select [[("<http://custom.agg>" ?x) ?sum]]
+                :where  [[?x ?y ?z]]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
+    (is (nil?
+         (->> '{:select   [?x]
+                :where    [[?x ?y ?z]]
+                :group-by [?x]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
+    (is (nil?
+         (->> '{:select   [[(sum ?x) ?x2] [(str ?x2) ?x3]]
+                :where    [[?x ?y ?z]]
+                :group-by [?x]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
+    (is (nil?
+         (->> '{:select   [?x]
+                :where    [{:select [[(sum ?y) ?sum]]
+                            :where [?x ?y ?z]}]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
+    (is (nil?
+         ;; Taken from select-agg-3.edn
+         (->> '{:select   [?g [(avg ?p) ?avg] [(/ (+ (min ?p) (max ?p)) 2) ?c]]
+                :where    [[?g "<http://my-pred.com>" ?p]]
+                :group-by [?g]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
     (is (= [{:kind ::va/invalid-aggregate-var
              :variables ['?z]}]
            (->> '{:select [[(sum ?x) ?sum] [(str ?z) ?str]]

--- a/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
@@ -106,7 +106,10 @@
          (->> '{:select [[(sum ?x) ?sum]]
                 :where  [[?x ?y ?z]]
                 :order-by [(sum ?x) ?y]
-                :having   [(sum ?x) (+ ?y ?y)]})))
+                :having   [(sum ?x) (+ ?y ?y)]}
+              (s/conform qs/query-spec)
+              v/collect-nodes
+              va/validate-agg-selects)))
     (is (nil?
          ;; Taken from select-agg-3.edn
          (->> '{:select   [?g [(avg ?p) ?avg] [(/ (+ (min ?p) (max ?p)) 2) ?c]]

--- a/src/test/com/yetanalytics/flint/validate/scope_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/scope_test.cljc
@@ -18,7 +18,7 @@
             '[:expr/as-var
               [[:expr/terminal [:ax/num-lit 2]]
                [:ax/var ?z]]])))
-    (is (= '[?y ?z]
+    (is (= '[?z]
            (vs/get-scope-vars
             '[:expr/as-var
               [[:expr/terminal [:ax/var ?y]]

--- a/src/test/com/yetanalytics/flint/validate/scope_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/scope_test.cljc
@@ -21,6 +21,12 @@
                [:ax/var ?z]]])))
     (is (= '[?z]
            (vv/get-scope-vars
+            '[:select/expr-as-var
+              [:expr/as-var
+               [[:expr/terminal [:ax/num-lit 2]]
+                [:ax/var ?z]]]])))
+    (is (= '[?z]
+           (vv/get-scope-vars
             '[:expr/as-var
               [[:expr/terminal [:ax/var ?y]]
                [:ax/var ?z]]])))
@@ -71,6 +77,17 @@
                           [[:triple/vec [[:ax/var ?x]
                                          [:ax/var ?y]
                                          [:ax/var ?z]]]]]]]])))
+      ;; This is an illegal sub-SELECT since it has both a wildcard and
+      ;; GROUP BY, but we want to cover all of our bases.
+      (is (= '[?x ?y ?z ?w]
+             (vv/get-scope-vars
+              '[:where-sub/select
+                [[:select [:ax/wildcard '*]]
+                 [:where [:where-sub/where
+                          [[:triple/vec [[:ax/var ?x]
+                                         [:ax/var ?y]
+                                         [:ax/var ?z]]]]]]
+                 [:group-by [[:ax/var ?w]]]]])))
       (is (= '[?a ?b ?c]
              (vv/get-scope-vars
               '[:where-sub/select
@@ -83,7 +100,10 @@
                  [:where [:where-sub/where
                           [[:triple/vec [[:ax/var ?x]
                                          [:ax/var ?y]
-                                         [:ax/var ?z]]]]]]]]))))
+                                         [:ax/var ?z]]]]]]
+                 [:group-by [[:ax/var ?a]
+                             [:ax/var ?b]
+                             [:ax/var ?c]]]]]))))
     (is (= '[?s1 ?p1 ?o1
              ?s2 ?p2 ?o2
              ?s3 ?p3 ?o3

--- a/src/test/com/yetanalytics/flint_test.cljc
+++ b/src/test/com/yetanalytics/flint_test.cljc
@@ -3,7 +3,6 @@
             [com.yetanalytics.flint :as flint :refer [format-query
                                                       format-update
                                                       format-updates]]
-            [com.yetanalytics.flint.validate.bnode :as vb]
             #?@(:clj [[clojure.string  :as cstr]
                       [clojure.edn     :as edn]
                       [clojure.java.io :as io]]))
@@ -111,7 +110,15 @@
                 (catch #?(:clj clojure.lang.ExceptionInfo
                           :cljs js/Error) e
                   (-> e ex-data :kind)))))
-    (is (= ::vb/dupe-bnodes-bgp
+    (is (= ::flint/invalid-aggregates
+           (try (format-query '{:prefixes {:foo "<http://foo.org/>"}
+                                :select *
+                                :where [[?x ?y ?z]]
+                                :group-by [?x]})
+                (catch #?(:clj clojure.lang.ExceptionInfo
+                          :cljs js/Error) e
+                  (-> e ex-data :kind)))))
+    (is (= ::flint/invalid-bnodes-bgp
            (try (format-query '{:prefixes {:foo "<http://foo.org/>"}
                                 :select [?x]
                                 :where [[?x :foo/bar _1]
@@ -119,7 +126,7 @@
                 (catch #?(:clj clojure.lang.ExceptionInfo
                           :cljs js/Error) e
                   (-> e ex-data :kind)))))
-    (is (= ::vb/dupe-bnodes-update
+    (is (= ::flint/invalid-bnodes-update
            (try (format-updates '[{:prefixes {:foo "<http://foo.org/>"}
                                    :insert-data [[:foo/bar :foo/baz _1]]}
                                   {:insert-data [[:foo/bar :foo/baz _1]]}])


### PR DESCRIPTION
Add additional checks to SELECT queries, such as:
- No duplicate projected variables
- Vars used in exprs in SELECT clauses are in scope
- Following the SPARQL spec on aggregates:
```clojure
;; In a query level which uses aggregates, only expressions consisting of
;; aggregates and constants may be projected, with one exception.
;; When GROUP BY is given with one or more simple expressions consisting of
;; just a variable, those variables may be projected from the level.
```