### PR TITLE
v0.1.0 Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## v0.1.1
+
+Fix a number of bugs discovered in v0.1.0 (see [Pull Request #20](https://github.com/yetanalytics/flint/pull/20)):
+- Allow IRIs and prefixed IRIs to be used in expressions.
+- Fix zipper traversal not working correctly with deletion or insertion quads.
+- Fix `java.time.Instant` instances not being formatted correctly.
+- Fix `a` not being valid in DELETE or INSERT queries.
+- Fix incorrect predicate specs for triples that restrict both blank nodes and variables.
+- Ensure parentheses are properly added around negated property paths.
+- Ensure parentheses around expressions are added for certain clauses (e.g. `FILTER`).
+
+Apply updates to the documentation:
+- Fix incorrect documentation on the `CONSTRUCT WHERE` query.
+- General grammar and cleanup fixes.
+
+## v0.1.0
+
+Initial release of Flint!

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 _The fire i' the flint shows not till it be struck_
 \- William Shakespeare, _Timon of Athens_, Act I, Scene 1
 
-A Clojure(Script) DSL for creating SPARQL Query and Update strings.
+A Clojure(Script) DSL for creating SPARQL query and update strings.
 
 ## Installation
 
@@ -44,7 +44,7 @@ Three functions exist in the Flint API:
 - `format-update`
 - `format-updates`
 
-The first two functions format a single SPARQL Query or Update, respectively, while the third formats a collection of SPARQL Updates into a single Update Request.
+The first two functions format a single SPARQL query or update, respectively, while the third formats a collection of SPARQL updates into a single update string.
 
 Each function takes in the following keyword arguments:
 
@@ -123,7 +123,7 @@ WHERE {
 ## Prior Art
 - Flint is based off of the grammar of [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/).
 - The idea of a SPARQL DSL was inspired by [HoneySQL](https://github.com/seancorfield/honeysql), a DSL for creating SQL queries.
-- Flint borrows certain syntactic conventions from the [Datalog grammar](https://docs.datomic.com/on-prem/query/query.html), including for terms, expressions, and variable binding.
+- Flint borrows certain syntactic conventions from the [Datomic](https://docs.datomic.com/on-prem/query/query.html) and [Asami](https://github.com/threatgrid/asami) query and update languages.
 - The map-based triples syntax is based on the normal form used in the [IGraph protocol](https://github.com/ont-app/igraph).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Clojure(Script) DSL for creating SPARQL query and update strings.
 Add the following to your `deps.edn` map.
 
 ```clojure
-com.yetanalytics/flint {:mvn/version "0.1.0"
+com.yetanalytics/flint {:mvn/version "0.1.1"
                         :exclusions [org.clojure/clojure
                                      org.clojure/clojurescript]}
 ```

--- a/doc/axiom.md
+++ b/doc/axiom.md
@@ -2,7 +2,7 @@
 
 Reference: [4.1 RDF Term Syntax](https://www.w3.org/TR/sparql11-query/#syntaxTerms)
 
-This section discusses IRIs, variables, blank nodes, and literals in Flint and SPARQL. Many of the conventions here, including for prefixed IRIs, variables, and blank nodes, were borrowed from the [Datalog grammar](https://docs.datomic.com/on-prem/query/query.html).
+This section discusses IRIs, variables, blank nodes, and literals in Flint and SPARQL. Many of the conventions here, including for prefixed IRIs, variables, and blank nodes, were borrowed from the [Datomic query and update grammar](https://docs.datomic.com/on-prem/query/query.html).
 
 **NOTE:** For simplicity, many terms in Flint only allow a subset of the characters that the SPARQL spec allows. For example, the latter often accepts Unicode characters, while Flint is ASCII-only outside of IRIs or string literals.
 
@@ -14,7 +14,7 @@ Internationalized Resource Identifiers (IRIs) and their subset Universal Resourc
 
 Examples: `<http://absolute-iri-example.com/>`, `<relative-iri>`
 
-Full IRIs in Flint are written as strings of the form `<my-iri-string>`. The string inside the angle bracket pair can include any characters **except** for `^`, `<`, `>`, `"`, `\`, `|`, `` ` ``, or whitespace. Translating to SPARQL does not change full IRIs.
+Full IRIs in Flint are written as strings of the form `<my-iri-string>`. The string inside the angle bracket pair can include any characters **except** for whitespace, `^`, `<`, `>`, `"`, `\`, `|`, or `` ` ``. Translating to SPARQL does not affect full IRIs.
 
 **NOTE:** This can mean that any string can become a IRI in Flint, though in practice they should conform to the [specification for IRIs](https://www.google.com/search?q=iri+spec&oq=IRI+spec&aqs=chrome.0.69i59j0i512j0i22i30l5.2040j0j7&sourceid=chrome&ie=UTF-8) after expansion.
 
@@ -24,9 +24,9 @@ Examples: `:my-prefix/foo`, `:bar`
 
 Prefixed IRIs in Flint are written as keywords of the form `:prefix/name`, where the prefix is optional. When translating to SPARQL, prefixed IRIs are transformed into the form `prefix:name`.
 
-Prefix IRIs accept word characters and hyphens, with the exception of the first prefix char (which does not allow digits); periods can also be included in the middle of the prefix.
+Prefixed IRIs accept word characters and hyphens, with the exception of the first prefix char (which does not allow digits); periods can also be included in the middle of the prefix.
 
-**NOTE:** Prefixed IRIs must have the prefix be an entry in the prefixes map; otherwise, validation will fail (unless `:validate?` is set to `false`).
+**NOTE:** Prefixed IRIs must have the prefix be an entry in the `:prefixes` map; otherwise, validation will fail (unless `:validate?` is set to `false`).
 
 ### `a`
 
@@ -60,15 +60,17 @@ Variables are written as symbols prefixed with a question mark `?`. The characte
 
 Examples: `_`, `_b0`
 
-Blank nodes are written as symbols prefixed with an underscore `_`. When translating to SPARQL, a colon is added after the underscore, e.g. `_:b0`. The exception is with `_`, which is rewritten as `[]`. The characters after the underscore can be written as any word character; periods are also allowed in the middle.
+Blank nodes are written as symbols prefixed with an underscore `_`. When translating a blank node to SPARQL, a colon is added after the underscore, e.g. `_:b0`. The exception is `_`, which is rewritten as `[]` instead.
 
-**NOTE:** Blank nodes have certain restrictions - they cannot be used in any delete-related clauses, nor can the same blank node be repeated across different [basic graph patterns](where.md) or SPARQL updates.
+The characters after the underscore can be written as any word character; periods are also allowed in the middle.
+
+**NOTE:** Blank nodes have certain restrictions: they cannot be used in any delete-related clauses, nor can the same blank node be repeated across different [basic graph patterns](where.md) or SPARQL updates.
 
 ## Wildcard:
 
 Examples: `*` and `:*`
 
-The wildcard is used in certain query clauses and expressions to denote "return everything". It can be written as either a symbol or keyword.
+The wildcard is used in certain query clauses and expressions in order to "return everything". It can be written as either a symbol or keyword.
 
 ## Literals
 
@@ -80,7 +82,7 @@ Flint supports the following literals: simple strings, language-tagged strings, 
 
 Examples: `0`, `-2`, `3.14`
 
-Numbers cover both integers and doubles, which are represented as integer and double literals in SPARQL. Neither are transformed during SPARQL translation beyond stringification
+Numbers cover both integers and doubles, which are represented as integer and double literals in SPARQL, respectively. Neither are transformed during SPARQL translation beyond stringification.
 
 ### Booleans
 
@@ -98,17 +100,17 @@ In Flint, string literals can contain any characters **except** unescaped line b
 
 Examples: `{:en "Hello World!"}`, `{:zh "你好世界"}`
 
-In Flint, strings with language tags are represented by a map between **one** language tag keyword and the string literal (which follows the same restrictions as above).
+In Flint, strings with language tags are represented by a map between **one** language tag keyword and the string literal (which follows the same restrictions as simple strings).
 
 ### dateTime timestamps
 
 Examples: `#inst "2022-01-01T10:10:10Z"`
 
-In Flint, dateTime timestamps include any values for which `inst?` is `true`. During SPARQL translation, an IRI denoting the type of the literal is added (since dateTime timestamps do not have a native representation in SPARQL):
+In Flint, dateTime timestamps are any values for which `inst?` is `true`. During SPARQL translation, an IRI denoting the datatype is added as a suffix (since dateTime timestamps, unlike other literals, do not have a non-suffixed representation in SPARQL):
 ```sparql
 "2022-01-01T10:10:10Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>
 ```
-However, if one includes an entry for the XMLSchema IRI prefix in their prefixes map, they can shorten the resulting string considerably; for example, if `:xsd` is associated with that prefix in the prefix map, then the string becomes:
+If one includes an entry for the XMLSchema IRI prefix in their prefixes map, they can shorten the resulting string considerably; for example, if that IRI prefix is associated with `:xsd`, then the string becomes:
 ```sparql
 "2022-01-01T10:10:10Z"^^xsd:dateTime
 ```

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -1,4 +1,5 @@
-{:cljdoc.doc/tree [["README" {:file "README.md"}]
+{:cljdoc.doc/tree [["Readme" {:file "README.md"}]
+                   ["Changelog" {:file "CHANGELOG.md"}]
                    ["Queries and Updates"
                     ["Queries" {:file "doc/query.md"}]
                     ["Updates" {:file "doc/update.md"}]]

--- a/doc/expr.md
+++ b/doc/expr.md
@@ -8,7 +8,7 @@ SPARQL supports expressions, which can be used to compute values and filter quer
 - As part of a [`:group-by`](modifier.md#group-by) clause, either as a freestanding expression or in an `[expr var]` form.
 - To aggregate or compute values in a [`:select`](query.md#select), [`:order-by`](modifier.md#order-by) or [`:having`](modifier.md#having) clause.
 
-In Flint, an expression is either a list of the form `(op expr...)`, similar to Clojure functions, or a terminal, which can be a [variable](axiom.md#variables) or [literal](axiom.md#literals).
+In Flint, an expression is either a list of the form `(op expr...)`, similar to Clojure functions, or a terminal, which can be a [variable](axiom.md#variables), an [IRI](axiom.md#iris) or a [literal](axiom.md#literals).
 
 Other than certain exceptions, like `exists` and `not-exists`, non-terminal expressions only accept other expressions as arguments.
 

--- a/doc/expr.md
+++ b/doc/expr.md
@@ -3,15 +3,14 @@
 Reference: [17. Expressions and Testing Values](https://www.w3.org/TR/sparql11-query/#expressions)
 
 SPARQL supports expressions, which can be used to compute values and filter query results. In particular, expressions can be used in the following circumstances:
-
 - As part of a [`:filter`](where.md#filter) clause.
 - As part of a [`:bind`](where.md#bind) clause, in an `[expr var]` form.
 - As part of a [`:group-by`](modifier.md#group-by) clause, either as a freestanding expression or in an `[expr var]` form.
 - To aggregate or compute values in a [`:select`](query.md#select), [`:order-by`](modifier.md#order-by) or [`:having`](modifier.md#having) clause.
 
-In Flint, an expression is either a list of the form `(op expr...)`, similar to Clojure functions, or either a [variable](axiom.md#variables) or [literal](axiom.md#literals) terminal.
+In Flint, an expression is either a list of the form `(op expr...)`, similar to Clojure functions, or a terminal, which can be a [variable](axiom.md#variables) or [literal](axiom.md#literals).
 
-With certain exceptions, like `exists` and `not-exists`, expressions only accept other expressions as arguments.
+Other than certain exceptions, like `exists` and `not-exists`, non-terminal expressions only accept other expressions as arguments.
 
 The following is an example of an expression in Flint:
 ```clojure
@@ -22,11 +21,11 @@ which is translated into SPARQL as:
 IF((?x < ?y), STR(?x), (2 * (3 + 4)))
 ```
 
-**NOTE:** Due to the complexity of SPARQL type semantics, Flint does not make any attempt to typecheck or validate expression arguments or return values. However, Flint does restrict the use of certain expressions (namely aggregators) to particular clauses, as explained later.
+**NOTE:** Due to the complexity of SPARQL type semantics, Flint does not make any attempt to typecheck or validate expression arguments or return values.
 
 ## Boolean and Arithmetic Expressions
 
-SPARQL supports boolean and arithmetic operations, with accept one or more expressions and return boolean or numeric values. Like all expressions, boolean and arithmetic ops are written in Clojure's prefix order in Flint, but are translated to SPARQL's infix order. (The exceptions are the unary `not` operator, as well as SPARQL's unary `+` and `-`, which are not supported in Flint.)
+SPARQL supports boolean and arithmetic operations, with accept one or more expression arguments and return boolean or numeric values. Like all expressions, boolean and arithmetic operations are written in Clojure's prefix order in Flint, but are translated to SPARQL's infix order. (The exceptions are the unary `not` operator, as well as SPARQL's unary `+` and `-` that are not supported in Flint.)
 
 The `in` and `not-in` operations are special boolean operations that are equivalent to `(or (= expr expr1) (= expr expr2) ...)` and `(and (not= expr expr1) (not= expr expr2) ...)`, respectively.
 
@@ -181,7 +180,7 @@ Aggregates are special expressions that can only be used in `SELECT` (and its `D
 | `count` | `COUNT` | `[expr-or-wildcard & {:keys [distinct?]}]`
 | `group-concat` | `GROUP_CONCAT` | `[expr & {:keys [distinct? separator]}]`
 
-The `count` aggregate can accept either a normal expression or a wildcard, so both (for example) `(count ?x)` and `(count *)` are valid.
+The `count` aggregate can accept either an expression or a wildcard, e.g. both `(count ?x)` and `(count *)` are valid.
 
 Unlike other expressions, aggregates in Flint support keyword arguments. Every aggregate function supports the `:distinct?` keyword arg, which accepts a boolean value. If `:distinct?` is `true`, then `DISTINCT` is added to the arg list in SPARQL. The example,
 ```clojure
@@ -192,7 +191,7 @@ becomes
 SUM(DISTINCT ?x)
 ```
 
-`group-concat` also accepts the `:separator` keyword arg that takes a separator string. Both `:distinct?` and `:separator` can be supported in the same expression, so:
+`group-concat` also accepts the `:separator` keyword arg whose value is a separator string. Both `:distinct?` and `:separator` can be supported in the same expression, as so:
 ```clojure
 (group-concat ?y :distinct? true :separator ";")
 ```

--- a/doc/expr.md
+++ b/doc/expr.md
@@ -39,7 +39,7 @@ The `in` and `not-in` operations are special boolean operations that are equival
 | `<` | `(expr < expr)` | `[expr expr]`
 | `>` | `(expr > expr)` | `[expr expr]`
 | `<=` | `(expr <= expr)` | `[expr expr]`
-| `?=` | `(expr >= expr)` | `[expr expr]`
+| `>=` | `(expr >= expr)` | `[expr expr]`
 | `+` | `(expr + expr + ...)` | `[expr & exprs]`
 | `-` | `(expr - expr - ...)` | `[expr & exprs]`
 | `*` | `(expr * expr * ...)` | `[expr & exprs]`

--- a/doc/expr.md
+++ b/doc/expr.md
@@ -163,7 +163,7 @@ String-specific predicates are listed under [Strings and Language Maps](expr.md#
 | `md5` | `MD5` | `[expr]` | [17.4.6.1](https://www.w3.org/TR/sparql11-query/#func-md5)
 | `sha1` | `SHA1` | `[expr]` | [17.4.6.2](https://www.w3.org/TR/sparql11-query/#func-sha1)
 | `sha256` | `SHA256` | `[expr]` | [17.4.6.3](https://www.w3.org/TR/sparql11-query/#func-sha256)
-| `SHA384` | `SHA384` | `[expr]` | [17.4.6.4](https://www.w3.org/TR/sparql11-query/#func-sha384)
+| `sha384` | `SHA384` | `[expr]` | [17.4.6.4](https://www.w3.org/TR/sparql11-query/#func-sha384)
 | `sha512` | `SHA512` | `[expr]` | [17.4.6.5](https://www.w3.org/TR/sparql11-query/#func-sha512)
 
 ## Aggregate Expressions

--- a/doc/graph.md
+++ b/doc/graph.md
@@ -6,7 +6,7 @@ SPARQL contains a number of clauses that can be used to specify default and name
 
 ### `:from`
 
-Used in queries, `:from` denotes the _default_ graph that the query operates on. Syntactically, the `:from` clause can be an IRI or prefixed, or a vector of **one** such IRI.
+Used in queries, `:from` denotes the _default_ graph that the query operates on. Syntactically, the `:from` clause can be an IRI or prefixed IRI, or a vector of **one** such IRI.
 
 The example:
 ```clojure
@@ -15,7 +15,7 @@ The example:
  :from     ["<http://my-default-graph.org/>"]
  :where    [[?x :foaf/name "Armin Arlet"]]}
 ```
-which becomes:
+becomes:
 ```sparql
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 SELECT ?x
@@ -27,7 +27,7 @@ WHERE {
 
 ### `:from-named`
 
-Used in updates, `:from-named` denotes the _named_ graphs that the query can operate on. Syntactically, the `:from-named` clause is a vector of one or more IRIs or prefixed IRIs.
+Used in queries, `:from-named` denotes the _named_ graphs that the query can operate on. Syntactically, the `:from-named` clause is a vector of one or more IRIs or prefixed IRIs.
 
 The example:
 ```clojure
@@ -40,7 +40,7 @@ The example:
                       [[:graph "<http://my-named-graph.org/v2>"
                                [[?x :foaf/name "Armin Arlet"]]]]]]}
 ```
-which becomes:
+becomes:
 ```sparql
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 SELECT ?x
@@ -98,7 +98,7 @@ WHERE {
 
 ### `:with`
 
-Used only in `:delete`/`:insert` updates, `:with` specifies the graph for the query. Syntactically, it consists an IRI or prefixed IRI that specifies the graph.
+Used only in `:delete`/`:insert` updates, `:with` specifies the graph being mutated by the update; it is similar to `:from` for queries. Syntactically, it consists an IRI or prefixed IRI that specifies the graph.
 
 The example:
 ```clojure

--- a/doc/modifier.md
+++ b/doc/modifier.md
@@ -2,7 +2,7 @@
 
 The following clauses are used at the top level of SPARQL query maps and are used to modify the solution or introduce new values. These modifiers include:
 
-- Inline values
+- Inlining values
   - [`:values`](modifier.md#values)
 - Grouping
   - [`:group-by`](modifier.md#group-by)
@@ -23,7 +23,7 @@ The `:values` clause associates values to variables in an inline fashion; it can
 - A literal value (number, string, etc.)
 - `nil`, which then becomes `UNDEF` during SPARQL translation.
 
-In Flint, the clause can be written in two ways. The first format follows how they are written in SPARQL, as a mapping of a variable vector to a collection of value vectors. For The example:
+In Flint, the clause can be written in two ways. The first format follows how they are written in SPARQL, as a mapping of a single variable vector to a collection of value vectors. For The example:
 ```clojure
 {:values {[?x ?y] [[:uri1 1] [:uri2 nil]]}}
 ```
@@ -36,15 +36,13 @@ VALUES (?x ?y) {
 ```
 which closely matches the original Clojure.
 
-However, there is a second format that is more idiomatic to Clojure - instead of having a singleton map between colls, each variable is a key to its own collection of values. In this way, the equivalent `:values` clause is:
+However, there is a second format that is more idiomatic to Clojure, where each variable is a key to its own collection of values. In this format, the equivalent `:values` clause is:
 ```clojure
 {:values {?x [:uri1 :uri2] ?y [1 nil]}}
 ```
-which then gets translated into the same SPARQL string.
+which is then translated into the same SPARQL string.
 
-A value can be one of the following:
-
-**NOTE:** In the first format, the number of variables must be equal to the number of value vectors. In addition, in both format the length of each value vector (including `nil` entries) must be the same.
+**NOTE:** In the first format, the number of variables must be equal to the number of value vectors. In addition, in both formats the length of each value vector (including `nil` entries) must be the same.
 
 The example:
 ```clojure
@@ -144,7 +142,7 @@ HAVING CONTAINS(STR(?org), "survey-corps")
 
 Reference: [15.1 ORDER BY](https://www.w3.org/TR/sparql11-query/#modOrderBy)
 
-An `:order-by` clause orders the result set. Syntactically, it consists of a vector of one or more of the following:
+An `:order-by` clause orders the results. Syntactically, it consists of a vector of one or more of the following:
 - Variables
 - Expressions (including aggregates)
 - `(asc expr)` or `(desc expr)` forms.
@@ -172,7 +170,7 @@ ORDER BY ASC(?age)
 
 Reference: [15.4 OFFSET](https://www.w3.org/TR/sparql11-query/#modOffset)
 
-The `:offset` clause adds a pagination offset to the result set. Syntactically, it must be an integer.
+The `:offset` clause adds a pagination offset to the results. Syntactically, it must be an integer.
 
 The example:
 ```clojure
@@ -195,7 +193,7 @@ OFFSET 2
 
 Reference: [15.5 LIMIT](https://www.w3.org/TR/sparql11-query/#modResultLimit)
 
-The `:limit` clause limits the size of the result set. Syntactically, it must be a non-negative integer.
+The `:limit` clause limits the number of results returned. Syntactically, it must be a non-negative integer.
 
 The example:
 ```clojure

--- a/doc/prologue.md
+++ b/doc/prologue.md
@@ -21,7 +21,7 @@ WHERE {
 }
 ```
 
-**NOTE:** The SPARQL spec allows for multiple base IRIs to be defined, but this is not allowed in Flint. Having multiple base IRIs means that each set of IRIs after a base will use a different base IRI. Since this is mainly useful for defining different bases for IRI prefixes, which clashes with Flint's approach of one `:prefixes` map per query or update.
+**NOTE:** The SPARQL spec allows for multiple base IRIs to be defined, but this is not allowed in Flint. Having multiple base IRIs means that each set of IRIs after a base will use a different base IRI. This is mainly useful for defining different bases for IRI prefixes, which clashes with Flint's approach of one `:prefixes` map per query or update.
 
 ### `:prefixes`
 
@@ -33,7 +33,7 @@ The `:prefixes` map associates prefix keywords to IRI prefixes. In the following
  :where    [[?x :foaf/name "Dr. X"]
             [?y :bar ?z]]}
 ```
-both `:foaf/name` and `:bar` are prefixed IRIs that are resolvable thanks to their prefixes having been defined in the `:prefixes` map. Note the special prefix `:$`, which represents the "null" prefix; this allows for prefixed IRIs like `:bar` to be written without a namespace, while ensuring that it is still expandable to a full IRI. The above query translates to:
+both `:foaf/name` and `:bar` are prefixed IRIs that are resolvable thanks to prefixes defined in the `:prefixes` map. Note the special prefix `:$`, which represents the "null" prefix; `:$` allows for prefixed IRIs like `:bar` to be written without a namespace, while ensuring that they are still expandable. The above query translates to:
 ```sparql
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX :     <http://foo.org/>
@@ -43,4 +43,4 @@ WHERE {
     ?y :bar ?z
 }
 ```
-While in SPARQL each prefix-IRI pair is preceded by `PREFIX`, the `:prefixes` map approach is more idiomatic to Clojure.
+While in SPARQL each prefix-IRI pair is separately preceded by `PREFIX`, the `:prefixes` map approach is more idiomatic to Clojure.

--- a/doc/query.md
+++ b/doc/query.md
@@ -1,7 +1,7 @@
 # SPARQL Queries
 
 A SPARQL query is used to find or test for values in an RDF graph database. There are four types of SPARQL queries:
-- [`:select`](query.md#select) (incl. [`:select-distinct`](query.md#select-distinct) and [`:select-reduced`](query.md#select-reduced))
+- [`:select`](query.md#select) (including [`:select-distinct`](query.md#select-distinct) and [`:select-reduced`](query.md#select-reduced))
 - [`:construct`](query.md#construct)
 - [`:ask`](query.md#ask)
 - [`:describe`](query.md#describe)
@@ -35,7 +35,7 @@ A `:select` query is used to select and return specific variables in a query. It
 - A wildcard: `*` or `:*`
 - A collection of variables or `[expr var]` forms.
 
-Example of a wildcard `:select`:
+This example of a wildcard `:select`:
 ```clojure
 {:prefixes {:foaf "<http://xmlns.com/foaf/0.1/>"}
  :select   *
@@ -50,7 +50,7 @@ WHERE {
 }
 ```
 
-Example of a `:select` with variables and `[expr var]` forms:
+This example of a `:select` with variables and `[expr var]` forms:
 ```clojure
 {:prefixes {:foaf "<http://xmlns.com/foaf/0.1/>"}
  :select   [?fullName [(<= 18 ?age) ?isAdult]]

--- a/doc/query.md
+++ b/doc/query.md
@@ -150,7 +150,7 @@ WHERE {
 }
 ```
 
-If the `:construct` clause is an empty collection or `nil`, then Flint will the query as the `CONSTRUCT WHERE` shorthand in SPARQL.
+If the `:construct` clause is an empty collection or `nil`, then Flint will interpret the query as using the `CONSTRUCT WHERE` shorthand in SPARQL.
 
 The example:
 ```clojure

--- a/doc/query.md
+++ b/doc/query.md
@@ -150,9 +150,26 @@ WHERE {
 }
 ```
 
-A `:construct` clause may contain zero triples, resulting in an empty RDF graph being returned.
+If the `:construct` clause is an empty collection or `nil`, then Flint will the query as the `CONSTRUCT WHERE` shorthand in SPARQL.
 
-**NOTE:** The `CONSTRUCT WHERE` shorthand is _not_ supported in Flint.
+The example:
+```clojure
+{:prefixes  {:foaf "<http://xmlns.com/foaf/0.1/>"}
+ :construct []
+ :where     [[?x :foaf/familyName "Jaeger"]
+             {?y {:foaf/familyName #{"Ackerman"}}}]}
+```
+becomes:
+```
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+CONSTRUCT
+WHERE {
+    ?x foaf:familyName "Jaeger" .
+    ?y foaf:familyName "Ackerman" .
+}
+```
+
+**NOTE:** Because of the above, it is not possible to use `:construct` queries to construct an empty model in Flint, even though it is valid in SPARQL.
 
 **NOTE:** Property paths are not allowed in the `:construct` clause (though they are still allowed in the `:where` clause).
 

--- a/doc/triple.md
+++ b/doc/triple.md
@@ -21,7 +21,7 @@ WHERE {
 }
 ```
 
-The other way to write a triple block in Flint is as a [normal form map](https://github.com/ont-app/igraph#normal-form) of the [IGraph protocol](https://github.com/ont-app/igraph). Each normal form map associates subjects with predicate-object maps, and each predicate-object map associates predicates with object sets. The example:
+The other way to write a triple block in Flint is the [normal form](https://github.com/ont-app/igraph#normal-form) of the [IGraph protocol](https://github.com/ont-app/igraph). Each normal form map associates subjects with predicate-object maps, and each predicate-object map associates predicates with object sets. The example:
 ```clojure
 {:prefixes {:foaf "<http://xmlns.com/foaf/0.1/>"}
  :select   [?name ?age]
@@ -126,7 +126,7 @@ Property paths act as syntactic sugar for predicate sequences in RDF graphs. A p
 | `?` | `(path)?` | `[path]`
 | `*` | `(path)*` | `[path]`
 | `+` | `(path)+` | `[path]`
-| `not` | `!neg-path` | `[neg-path]`
+| `not` | `!(neg-path)` | `[neg-path]`
 
 A `neg-path` is a subset of paths that can only include `alt` operations or IRIs. No other operations are allowed, even as args to `alt` ops.
 
@@ -137,7 +137,7 @@ An example of a query with a simple property path:
  :where    [{?x {:foaf/name #{"Eren Jaeger"}
                 (cat (* :foaf/knows) :foaf/name) #{?friendName}}}]}
 ```
-which becomes:
+becomes:
 ```sparql
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 SELECT ?friendName

--- a/doc/update.md
+++ b/doc/update.md
@@ -33,7 +33,7 @@ Each SPARQL update in Flint is a map that includes one of the aforementioned cla
 - `:add`, `:move`, and `:copy`-specific clauses:
   - `:to`
 
-The triple insertion and deletion clauses accept both [triples](triple.md) and _quads_, which have the form `[:graph iri triples]`. This is similar to the `:graph` clause in [graph patterns](where.md), except that variables cannot be substituted in the graph IRI position.
+Insertion and deletion clauses accept both [triples](triple.md) and _quads_, which have the form `[:graph iri triples]`. This is similar to the `:graph` clause in [graph patterns](where.md), except that variables cannot be substituted in the graph IRI position.
 
 **NOTE:** Any key other than the above keywords is not allowed in a SPARQL update map.
 
@@ -95,7 +95,7 @@ DELETE DATA {
 
 Reference: [3.1.3 DELETE/INSERT](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#delete)
 
-A `:delete` or `:insert` clause deletes or inserts triples, respectively, in an RDF graph with variables specified by a `:where` clause. Syntactically, both clauses consists of triples or quads. An update may contain either a `:delete` clause, an `:insert` clause, or both.
+A `:delete` or `:insert` clause deletes or inserts triples, respectively, in an RDF graph with variables specified by a `:where` clause. Syntactically, both clauses consist of triples or quads. An update may contain either a `:delete` clause, an `:insert` clause, or both.
 
 The example:
 ```clojure
@@ -189,7 +189,7 @@ INTO <http://census.marley/data>
 
 Reference: [3.1.5 CLEAR](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#clear)
 
-The `:clear` update is used to clear all data from one or more RDF graphs. Syntactically, the `:clear` clause consists of either an explicit IRI or prefixed IRI, `:default`, `:named`, or `:all`.
+The `:clear` update is used to clear all data from one or more RDF graphs. Syntactically, the `:clear` clause consists of either an IRI, prefixed IRI, `:default`, `:named`, or `:all`.
 
 The example:
 ```clojure
@@ -204,7 +204,7 @@ CLEAR DEFAULT
 
 Reference: [3.2.1 CREATE](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#create)
 
-The `:create` update creates a new empty graph in an RDF store. The `:create` clause consists of the IRI or prefixed of the new graph.
+The `:create` update creates a new empty graph in an RDF store. The `:create` clause consists of the IRI or prefixed IRI of the new graph.
 
 The example:
 ```clojure
@@ -221,7 +221,7 @@ CREATE census:data
 
 Reference: [3.2.2 DROP](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#drop)
 
-The `:drop` update deletes one or more graphs in an RDF store. The `:drop` clause consists of either an explicit IRI or prefixed IRI, `:default`, `:named`, or `:all`.
+The `:drop` update deletes one or more graphs in an RDF store. The `:drop` clause consists of either an IRI, prefixed IRI, `:default`, `:named`, or `:all`.
 
 The example:
 ```clojure
@@ -236,7 +236,7 @@ DROP DEFAULT
 
 Reference: [3.2.3 COPY](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#copy)
 
-The `:copy` update transfers data from a source to a target graph, overwriting the latter in the process. Both the `:copy` and `:to` clauses consist of either an IRI or prefixed IRI or the `:default` keyword.
+The `:copy` update transfers data from a source to a target graph, overwriting the latter in the process. Both the `:copy` and `:to` clauses consist of either an IRI, prefixed IRI or the `:default` keyword.
 
 The example:
 ```clojure
@@ -253,7 +253,7 @@ TO DEFAULT
 
 Reference: [3.2.4 MOVE](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#move)
 
-The `:move` update moves data from a source to a target graph, deleting the former and overwriting the latter. Both the `:move` and `:to` clauses consist of either an IRI or prefixed IRI or the `:default` keyword.
+The `:move` update moves data from a source to a target graph, deleting the former and overwriting the latter. Both the `:move` and `:to` clauses consist of either an IRI, prefixed IRI or the `:default` keyword.
 
 The example:
 ```clojure
@@ -270,7 +270,7 @@ TO DEFAULT
 
 Reference: [3.2.5 ADD](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#add)
 
-The `:add` update appends data from a source to a target graph. Both the `:add` and `:to` clauses consist of either an IRI or prefixed IRI or the `:default` keyword.
+The `:add` update appends data from a source to a target graph. Both the `:add` and `:to` clauses consist of either an IRI, prefixed IRI or the `:default` keyword.
 
 The example:
 ```clojure

--- a/doc/where.md
+++ b/doc/where.md
@@ -1,6 +1,6 @@
 # Graph Patterns
 
-SPARQL/Flint `:where` clauses are written as _graph patterns_, which describe a selection of RDF triples. The simplest graph pattern, known as a _basic graph pattern_ (or BGP) consists of a series of RDF triples.* However, there are a number of clauses that can be used to create more advanced graph patterns:
+SPARQL/Flint `:where` clauses are written as _graph patterns_, which describe a selection of RDF triples. The simplest graph pattern, known as a _basic graph pattern_ (BGP) consists of a series of RDF triples.* However, there are a number of clauses that can be used to create more advanced graph patterns:
 - [`:where`](where.md#where)
 - [`:optional`](where.md#optional)
 - [`:union`](where.md#union)
@@ -23,7 +23,7 @@ A `:where` clause in Flint is one of two things:
 - A sub-query, which is written as a `:select` query map.
 - A vector of graph patterns.
 
-Each graph pattern is written as either a [triple](triple.md) (either as a vector or IGraph normal form map), or as a vector of the form `[:keyword & args]`.
+Each `:where` graph pattern is written as either a [triple](triple.md) (either as a vector or IGraph normal form map), or as a vector of the form `[:keyword & args]`. `:where` patterns can be nested within each other.
 
 Example of a `:where` clause containing a subquery in a nested `:where`:
 ```clojure
@@ -56,11 +56,13 @@ WHERE {
 }
 ```
 
+**NOTE:** Unlike their top-level counterparts, sub-`:select` queries cannot accept prologue, `:from` or `:from-named` clauses.
+
 ### `:optional`
 
 Reference: [6. Including Optional Values](https://www.w3.org/TR/sparql11-query/#optionals)
 
-The `:optional` keyword specifies patterns that do not need to exist in the solution. In Flint, an `:optional` graph pattern has the form `[:optional sub-where]`.
+The `:optional` keyword specifies graph patterns that do not need to be matched in order to form a query solution. In Flint, an `:optional` graph pattern has the form `[:optional sub-where]`.
 
 The example:
 ```clojure
@@ -85,7 +87,7 @@ WHERE {
 
 Reference: [7. Matching Alternatives](https://www.w3.org/TR/sparql11-query/#alternatives)
 
-The `:union` keyword takes the union of the results of multiple graph patterns. In Flint, a `:union` graph pattern has the form `[:union sub-where & sub-wheres]`.
+The `:union` keyword specifies taking the union of the results of multiple graph patterns. In Flint, a `:union` graph pattern has the form `[:union sub-where & sub-wheres]`.
 
 The example:
 ```clojure
@@ -248,7 +250,7 @@ WHERE {
 
 Reference: [SPARQL 1.1 Federated Query](https://www.w3.org/TR/2013/REC-sparql11-federated-query-20130321/)
 
-The `:service` keyword is used for federated queries, i.e. queries across networks. The `:service-silent` variant is used for queries to fail silently. In Flint, the `:service` graph pattern has the form `[:service iri-or-var sub-where]`.
+The `:service` keyword is used for federated queries, i.e. queries across networks. The `:service-silent` variant is used in order to fail silently. In Flint, the `:service` graph pattern has the form `[:service iri-or-var sub-where]`.
 
 The example:
 ```clojure

--- a/src/main/com/yetanalytics/flint/format.cljc
+++ b/src/main/com/yetanalytics/flint/format.cljc
@@ -7,6 +7,21 @@
 ;; Helpers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defn bracketted-expr-str?
+  [s]
+  (boolean (re-matches #"\(.*\)" s)))
+
+(defn bracketted-or-fn-expr-str?
+  "Determine if a expression string represents a bracketted expression or
+   a function call."
+  [s]
+  (boolean (or (re-matches #"\(.*\)" s)
+               ;; Built-ins, IRI, and prefixed IRI functions
+               (re-matches #"[\<\w\-].*\(.*\)" s)
+               ;; (NOT) EXISTS doesn't use parens
+               (cstr/starts-with? s "EXISTS")
+               (cstr/starts-with? s "NOT EXISTS"))))
+
 (defn indent-str
   "Add 4 spaces after each line break (including at the beginning)."
   [s]

--- a/src/main/com/yetanalytics/flint/format/modifier.cljc
+++ b/src/main/com/yetanalytics/flint/format/modifier.cljc
@@ -7,25 +7,38 @@
 
 (defmethod f/format-ast-node :mod/asc-desc [_ [_ [op sub-expr]]]
   (let [op-name (cstr/upper-case op)]
-    (str op-name "(" sub-expr ")")))
+    (str op-name sub-expr)))
 
-(defmethod f/format-ast-node :mod/expr [_ [_ expr]]
+(defmethod f/format-ast-node :mod/asc-desc-expr [_ [_ expr]]
+  (if (f/bracketted-expr-str? expr)
+    expr
+    (str "(" expr ")")))
+
+(defmethod f/format-ast-node :mod/group-expr [_ [_ expr]]
   expr)
+
+(defmethod f/format-ast-node :mod/order-expr [_ [_ expr]]
+  (if (f/bracketted-or-fn-expr-str? expr)
+    expr
+    (str "(" expr ")")))
 
 (defmethod f/format-ast-node :mod/expr-as-var [_ [_ expr-as-var]]
   (str "(" expr-as-var ")"))
 
-(defmethod f/format-ast-node :group-by [_ [_ value]]
-  (str "GROUP BY " (cstr/join " " value)))
+(defmethod f/format-ast-node :group-by [_ [_ group-bys]]
+  (str "GROUP BY " (cstr/join " " group-bys)))
 
-(defmethod f/format-ast-node :order-by [_ [_ value]]
-  (str "ORDER BY " (cstr/join " " value)))
+(defmethod f/format-ast-node :order-by [_ [_ order-bys]]
+  (str "ORDER BY " (cstr/join " " order-bys)))
 
-(defmethod f/format-ast-node :having [_ [_ value]]
-  (str "HAVING " (cstr/join " " value)))
+(defmethod f/format-ast-node :having [_ [_ exprs]]
+  (->> exprs
+       (map (fn [e] (if (f/bracketted-or-fn-expr-str? e) e (str "(" e ")"))))
+       (cstr/join " ")
+       (str "HAVING ")))
 
-(defmethod f/format-ast-node :limit [_ [_ value]]
-  (str "LIMIT " value))
+(defmethod f/format-ast-node :limit [_ [_ limit-val]]
+  (str "LIMIT " limit-val))
 
-(defmethod f/format-ast-node :offset [_ [_ value]]
-  (str "OFFSET " value))
+(defmethod f/format-ast-node :offset [_ [_ offset-val]]
+  (str "OFFSET " offset-val))

--- a/src/main/com/yetanalytics/flint/format/path.cljc
+++ b/src/main/com/yetanalytics/flint/format/path.cljc
@@ -11,7 +11,15 @@
   "Super-basic precedence comparison to wrap parens if there's an inner
    unary regex op, since paths like `a?*+` are illegal."
   [arg]
-  (if (re-matches #".*(\?|\*|\+)" arg)
+  (if (or (re-matches #".*(\?|\*|\+)" arg)
+          (re-matches #"\!.*" arg))
+    (str "(" arg ")")
+    arg))
+
+(defn- parens-if-nests-neg
+  "Similar to `parens-if-nests` but speficially for `!`."
+  [arg]
+  (if (re-matches #"\!.*" arg)
     (str "(" arg ")")
     arg))
 
@@ -23,7 +31,7 @@
     :?   (-> paths first parens-if-nests (str "?"))
     :*   (-> paths first parens-if-nests (str "*"))
     :+   (-> paths first parens-if-nests (str "+"))
-    :not (str "!" (cstr/join " | " paths))))
+    :not (->> paths first parens-if-nests-neg (str "!"))))
 
 (defmethod f/format-ast-node :path/terminal [_ [_ value]]
   value)

--- a/src/main/com/yetanalytics/flint/format/update.cljc
+++ b/src/main/com/yetanalytics/flint/format/update.cljc
@@ -29,8 +29,13 @@
 (defmethod f/format-ast-node :update/named-graph [_ [_ iri]]
   iri)
 
-(defmethod f/format-ast-node :triple/quads [{:keys [pretty?]} [_ [_ var-or-iri triples]]]
-  (str "GRAPH " var-or-iri " " (format-quads triples pretty?)))
+(defmethod f/format-ast-node :triple/quads
+  [_ [_ [var-or-iri triples-str]]]
+  (str "GRAPH " var-or-iri " " triples-str))
+
+(defmethod f/format-ast-node :triple/quad-triples
+  [{:keys [pretty?]} [_ triples]]
+  (format-quads triples pretty?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Graph Management specs

--- a/src/main/com/yetanalytics/flint/format/where.cljc
+++ b/src/main/com/yetanalytics/flint/format/where.cljc
@@ -45,7 +45,9 @@
   (str "SERVICE SILENT " iri " " pattern))
 
 (defmethod f/format-ast-node :where/filter [_ [_ expr]]
-  (str "FILTER " expr))
+  (if (f/bracketted-or-fn-expr-str? expr)
+    (str "FILTER " expr)
+    (str "FILTER (" expr ")")))
 
 (defmethod f/format-ast-node :where/bind [_ [_ expr-as-var]]
   (str "BIND (" expr-as-var ")"))

--- a/src/main/com/yetanalytics/flint/spec/expr.cljc
+++ b/src/main/com/yetanalytics/flint/spec/expr.cljc
@@ -10,12 +10,14 @@
 (def expr-terminal-spec
   (s/and
    (comp not list?)
-   (s/or :ax/var      ax/variable?
-         :ax/num-lit  number?
-         :ax/bool-lit boolean?
-         :ax/str-lit  ax/valid-string?
-         :ax/lmap-lit ax/lang-map?
-         :ax/dt-lit   inst?)))
+   (s/or :ax/iri        ax/iri?
+         :ax/prefix-iri ax/prefix-iri?
+         :ax/var        ax/variable?
+         :ax/num-lit    number?
+         :ax/bool-lit   boolean?
+         :ax/str-lit    ax/valid-string?
+         :ax/lmap-lit   ax/lang-map?
+         :ax/dt-lit     inst?)))
 
 (def var-terminal-spec
   (s/or :expr/terminal

--- a/src/main/com/yetanalytics/flint/spec/modifier.cljc
+++ b/src/main/com/yetanalytics/flint/spec/modifier.cljc
@@ -3,19 +3,22 @@
             [com.yetanalytics.flint.spec.axiom :as ax]
             [com.yetanalytics.flint.spec.expr  :as es]))
 
+;; TODO: Need to restrict `mod/group-expr` to function calls.
+;; However, this may count as a breaking change.
+
 (s/def ::group-by
   (s/coll-of (s/or :ax/var          ax/variable?
-                   :mod/expr        ::es/expr
+                   :mod/group-expr  ::es/expr
                    :mod/expr-as-var ::es/expr-as-var)
              :min-count 1
              :kind vector?))
 
 (s/def ::order-by
-  (s/coll-of (s/or :ax/var       ax/variable?
-                   :mod/asc-desc (s/& (s/cat :mod/op #{'asc 'desc}
-                                             :mod/expr ::es/agg-expr)
-                                      (s/conformer #(into [] %)))
-                   :mod/expr     ::es/agg-expr)
+  (s/coll-of (s/or :ax/var         ax/variable?
+                   :mod/asc-desc   (s/& (s/cat :mod/op #{'asc 'desc}
+                                               :mod/asc-desc-expr ::es/agg-expr)
+                                        (s/conformer #(into [] %)))
+                   :mod/order-expr ::es/agg-expr)
              :min-count 1
              :kind vector?))
 

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -61,7 +61,8 @@
 
 (def pred-novar-spec
   (s/or :ax/iri ax/iri?
-        :ax/prefix-iri ax/prefix-iri?))
+        :ax/prefix-iri ax/prefix-iri?
+        :ax/rdf-type ax/rdf-type?))
 
 ;; Objects
 

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -159,7 +159,7 @@
   (make-pred-objs-spec pred-nopath-spec obj-set-noblank-spec))
 
 (def pred-objs-novar-noblank-spec
-  (make-pred-objs-spec pred-nopath-spec obj-set-novar-noblank-spec))
+  (make-pred-objs-spec pred-novar-spec obj-set-novar-noblank-spec))
 
 ;; Subject Predicate Object
 
@@ -200,4 +200,4 @@
   (s/tuple subj-noblank-spec pred-nopath-spec obj-noblank-spec))
 
 (def triple-vec-novar-noblank-spec
-  (s/tuple subj-novar-noblank-spec pred-nopath-spec obj-novar-noblank-spec))
+  (s/tuple subj-novar-noblank-spec pred-novar-spec obj-novar-noblank-spec))

--- a/src/main/com/yetanalytics/flint/spec/update.cljc
+++ b/src/main/com/yetanalytics/flint/spec/update.cljc
@@ -86,24 +86,28 @@
              :kind vector?))
 
 (def quad-spec
-  (s/tuple #{:graph}
-           ax/var-or-iri-spec
-           triples-spec))
+  (s/and (s/tuple #{:graph}
+                  ax/var-or-iri-spec
+                  (s/or :triple/quad-triples triples-spec))
+         (s/conformer (fn [[_ iri t]] [iri t]))))
 
 (def quad-novar-spec
-  (s/tuple #{:graph}
-           ax/var-or-iri-spec
-           triples-novar-spec))
+  (s/and (s/tuple #{:graph}
+                  ax/var-or-iri-spec
+                  (s/or :triple/quad-triples triples-novar-spec))
+         (s/conformer (fn [[_ iri t]] [iri t]))))
 
 (def quad-noblank-spec
-  (s/tuple #{:graph}
-           ax/var-or-iri-spec
-           triples-noblank-spec))
+  (s/and (s/tuple #{:graph}
+                  ax/var-or-iri-spec
+                  (s/or :triple/quad-triples triples-noblank-spec))
+         (s/conformer (fn [[_ iri t]] [iri t]))))
 
 (def quad-novar-noblank-spec
-  (s/tuple #{:graph}
-           ax/var-or-iri-spec
-           triples-novar-noblank-spec))
+  (s/and (s/tuple #{:graph}
+                  ax/var-or-iri-spec
+                  (s/or :triple/quad-triples triples-novar-noblank-spec))
+         (s/conformer (fn [[_ iri t]] [iri t]))))
 
 (def triple-or-quads-spec
   (s/coll-of (s/or :triple/vec  ts/triple-vec-nopath-spec

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -61,7 +61,7 @@
        (map group-by-projected-vars)
        (filter some?)))
 
-(defmethod group-by-projected-vars :mod/expr [_] nil)
+(defmethod group-by-projected-vars :mod/group-expr [_] nil)
 
 (defmethod group-by-projected-vars :ax/var [[_ v]] v)
 

--- a/src/test/com/yetanalytics/flint/format/axiom_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/axiom_test.cljc
@@ -41,4 +41,21 @@
                    :cljs "\"2022-01-20T16:22:19.000Z\"")
                 "^^xsd:dateTime")
            (f/format-ast-node {:xsd-prefix "xsd"}
-                              [:ax/dt-lit #inst "2022-01-20T16:22:19Z"])))))
+                              [:ax/dt-lit #inst "2022-01-20T16:22:19Z"]))))
+  (testing "DateTime formatting works on all `inst?` timestamps"
+    #?(:clj (let [ts-str-1 "\"2022-01-20T16:22:19Z\"^^xsd:dateTime"
+                  ts-str-2 "\"1970-01-01T00:00:00Z\"^^xsd:dateTime"
+                  literal  #inst "2022-01-20T16:22:19Z"
+                  instant  (java.time.Instant/parse "2022-01-20T16:22:19Z")
+                  date     (java.util.Date/from instant)
+                  fmt-ts   (fn [ts] (f/format-ast-node {:xsd-prefix "xsd"}
+                                                       [:ax/dt-lit ts]))]
+              (is (= ts-str-1 (fmt-ts literal)))
+              (is (= ts-str-1 (fmt-ts instant)))
+              (is (= ts-str-1 (fmt-ts date)))
+              (is (= ts-str-2 (fmt-ts (java.sql.Timestamp. 0))))
+              (is (= ts-str-2 (fmt-ts (java.sql.Time. 0))))
+              (is (= ts-str-2 (fmt-ts (java.sql.Date. 0)))))
+       :cljs (is (string?
+                  (f/format-ast-node {:xsd-prefix "xsd"}
+                                     [:ax/dt-lit (js/Date.)]))))))

--- a/src/test/com/yetanalytics/flint/format/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/expr_test.cljc
@@ -27,6 +27,10 @@
                                 [:expr/args [[:expr/branch [[:expr/op not]
                                                             [:expr/args [[:expr/terminal [:ax/bool-lit false]]]]]]]]]]
                 format-ast)))
+    (is (= "!(-2)"
+           (->> '[:expr/branch [[:expr/op not]
+                                [:expr/args [[:expr/terminal [:ax/num-lit -2]]]]]]
+                format-ast)))
     (is (= "(1 IN (1, 2, 3))"
            (->> '[:expr/branch [[:expr/op in]
                                 [:expr/args [[:expr/terminal [:ax/num-lit 1]]

--- a/src/test/com/yetanalytics/flint/format/path_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/path_test.cljc
@@ -64,6 +64,31 @@
                                    [:path/paths [[:path/branch
                                                   [[:path/op ?]
                                                    [:path/paths [[:path/terminal [:ax/rdf-type 'a]]]]]]]]]]]]]]
+                format-ast)))
+    (is (= "(!a)*"
+           (->> '[:path/branch
+                  [[:path/op *]
+                   [:path/paths [[:path/branch
+                                  [[:path/op not]
+                                   [:path/paths [[:path/terminal [:ax/rdf-type 'a]]]]]]]]]]
+                format-ast)))
+    (is (= "((!a)*)?"
+           (->> '[:path/branch
+                  [[:path/op ?]
+                   [:path/paths [[:path/branch
+                                  [[:path/op *]
+                                   [:path/paths [[:path/branch
+                                                  [[:path/op not]
+                                                   [:path/paths [[:path/terminal [:ax/rdf-type 'a]]]]]]]]]]]]]]
+                format-ast)))
+    (is (= "!(!(!a))"
+           (->> '[:path/branch
+                  [[:path/op not]
+                   [:path/paths [[:path/branch
+                                  [[:path/op not]
+                                   [:path/paths [[:path/branch
+                                                  [[:path/op not]
+                                                   [:path/paths [[:path/terminal [:ax/rdf-type 'a]]]]]]]]]]]]]]
                 format-ast)))))
 
 (deftest format-invalid-test

--- a/src/test/com/yetanalytics/flint/format/query_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/query_test.cljc
@@ -28,7 +28,7 @@
                                                             [:ax/var ?z]]]]]]
                    [:order-by [[:mod/asc-desc
                                 [[:mod/op asc]
-                                 [:mod/expr [:expr/terminal [:ax/var ?y]]]]]]]
+                                 [:mod/asc-desc-expr [:expr/terminal [:ax/var ?y]]]]]]]
                    [:values [:values/map
                              [[[:ax/var ?z]]
                               [[[:ax/num-lit 1]]]]]]]]

--- a/src/test/com/yetanalytics/flint/format/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/update_test.cljc
@@ -25,11 +25,12 @@
                             "}"])
            (->> '[:update/delete-data
                   [[:delete-data
-                    [[:triple/quads [:graph
-                                     [:ax/iri "<http://example.org>"]
-                                     [[:triple/vec [[:ax/prefix-iri :foo/x]
-                                                    [:ax/prefix-iri :dc/title]
-                                                    [:ax/str-lit "Title"]]]]]]]]]]
+                    [[:triple/quads
+                      [[:ax/iri "<http://example.org>"]
+                       [:triple/quad-triples
+                        [[:triple/vec [[:ax/prefix-iri :foo/x]
+                                       [:ax/prefix-iri :dc/title]
+                                       [:ax/str-lit "Title"]]]]]]]]]]]
                 format-ast))))
   (testing "Formatting DELETE WHERE clauses"
     (is (= (cstr/join "\n" ["DELETE WHERE {"
@@ -61,9 +62,9 @@
                                      [:triple/po [[[:ax/var ?p]
                                                    [:triple/o [[:ax/var ?o]]]]]]]]]]
                      [:triple/quads
-                      [:graph
-                       [:ax/iri "<http://example.org>"]
-                       [[:triple/vec [[:ax/var ?q] [:ax/var ?r] [:ax/var ?s]]]]]]]]]]
+                      [[:ax/iri "<http://example.org>"]
+                       [:triple/quad-triples
+                        [[:triple/vec [[:ax/var ?q] [:ax/var ?r] [:ax/var ?s]]]]]]]]]]]
                 format-ast))))
   (testing "Formatting DELETE...INSERT clauses"
     (is (= (cstr/join "\n" ["INSERT {"

--- a/src/test/com/yetanalytics/flint/format/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/where_test.cljc
@@ -43,6 +43,7 @@
                             "        ?s10 ?p10 ?o10 ."
                             "    }"
                             "    BIND ((2 + 2) AS ?foo)"
+                            "    FILTER (!false)"
                             "    FILTER (2 = ?bar)"
                             "    FILTER ns:myfn(2, ?baz)"
                             "    VALUES (?x ?y) {"
@@ -92,6 +93,11 @@
                         ([:expr/terminal [:ax/num-lit 2]]
                          [:expr/terminal [:ax/num-lit 2]])]]]
                      [:ax/var ?foo]]]]
+                  [:where/filter
+                   [:expr/branch
+                    [[:expr/op not]
+                     [:expr/args
+                      ([:expr/terminal [:ax/bool-lit false]])]]]]
                   [:where/filter
                    [:expr/branch
                     [[:expr/op =]

--- a/src/test/com/yetanalytics/flint/spec/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/expr_test.cljc
@@ -11,6 +11,10 @@
       (is (s/valid? ::es/expr "bar"))
       (is (s/valid? ::es/expr 2))
       (is (s/valid? ::es/expr false))
+      (is (= [:expr/terminal [:ax/iri "<http://foo.org>"]]
+             (s/conform ::es/expr "<http://foo.org>")))
+      (is (= [:expr/terminal [:ax/prefix-iri :foo/bar]]
+             (s/conform ::es/expr :foo/bar)))
       (is (= [:expr/terminal [:ax/var '?foo]]
              (s/conform ::es/expr '?foo)))
       (is (= [:expr/terminal [:ax/dt-lit #inst "2022-01-19T22:20:49Z"]]

--- a/src/test/com/yetanalytics/flint/spec/modifier_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/modifier_test.cljc
@@ -18,12 +18,12 @@
            (s/conform ::ms/order-by '[?foo])))
     (is (= '[[:mod/asc-desc
               [[:mod/op asc]
-               [:mod/expr [:expr/terminal [:ax/var ?bar]]]]]]
+               [:mod/asc-desc-expr [:expr/terminal [:ax/var ?bar]]]]]]
            (s/conform ::ms/order-by '[(asc ?bar)])))
     (is (= '[[:ax/var ?foo]
              [:mod/asc-desc
               [[:mod/op asc]
-               [:mod/expr [:expr/terminal [:ax/var ?bar]]]]]]
+               [:mod/asc-desc-expr [:expr/terminal [:ax/var ?bar]]]]]]
            (s/conform ::ms/order-by '[?foo (asc ?bar)])))
     (is (= '[[:expr/terminal [:ax/num-lit 1]]
              [:expr/terminal [:ax/num-lit 2]]

--- a/src/test/com/yetanalytics/flint/spec/query_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/query_test.cljc
@@ -23,7 +23,7 @@
                                                        [:ax/var ?z]]]]]]
               [:order-by [[:mod/asc-desc
                            [[:mod/op asc]
-                            [:mod/expr [:expr/terminal [:ax/var ?y]]]]]]]
+                            [:mod/asc-desc-expr [:expr/terminal [:ax/var ?y]]]]]]]
               [:values [:values/map
                         [[[:ax/var ?z]]
                          [[[:ax/num-lit 1]]]]]]]]

--- a/src/test/com/yetanalytics/flint/spec/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/update_test.cljc
@@ -10,11 +10,11 @@
                                           [:ax/str-lit "Title"]]]]]]
            (s/conform us/insert-data-update-spec
                       '{:insert-data [[:foo/x :dc/title "Title"]]})))
-    (is (= '[[:delete-data [[:triple/quads [:graph
-                                            [:ax/iri "<http://example.org>"]
-                                            [[:triple/vec [[:ax/prefix-iri :foo/x]
-                                                           [:ax/prefix-iri :dc/title]
-                                                           [:ax/str-lit "Title"]]]]]]]]]
+    (is (= '[[:delete-data [[:triple/quads [[:ax/iri "<http://example.org>"]
+                                            [:triple/quad-triples
+                                             [[:triple/vec [[:ax/prefix-iri :foo/x]
+                                                            [:ax/prefix-iri :dc/title]
+                                                            [:ax/str-lit "Title"]]]]]]]]]]
            (s/conform us/delete-data-update-spec
                       '{:delete-data [[:graph
                                        "<http://example.org>"

--- a/src/test/com/yetanalytics/flint/spec/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/update_test.cljc
@@ -7,18 +7,27 @@
   (testing "Conforming updates"
     (is (= '[[:insert-data [[:triple/vec [[:ax/prefix-iri :foo/x]
                                           [:ax/prefix-iri :dc/title]
-                                          [:ax/str-lit "Title"]]]]]]
+                                          [:ax/str-lit "Title"]]]
+                            [:triple/vec [[:ax/prefix-iri :foo/y]
+                                          [:ax/rdf-type :a]
+                                          [:ax/str-lit "MyType"]]]]]]
            (s/conform us/insert-data-update-spec
-                      '{:insert-data [[:foo/x :dc/title "Title"]]})))
-    (is (= '[[:delete-data [[:triple/quads [[:ax/iri "<http://example.org>"]
-                                            [:triple/quad-triples
-                                             [[:triple/vec [[:ax/prefix-iri :foo/x]
-                                                            [:ax/prefix-iri :dc/title]
-                                                            [:ax/str-lit "Title"]]]]]]]]]]
+                      '{:insert-data [[:foo/x :dc/title "Title"]
+                                      [:foo/y :a "MyType"]]})))
+    (is (= '[[:delete-data [[:triple/quads
+                             [[:ax/iri "<http://example.org>"]
+                              [:triple/quad-triples
+                               [[:triple/vec [[:ax/prefix-iri :foo/x]
+                                              [:ax/prefix-iri :dc/title]
+                                              [:ax/str-lit "Title"]]]
+                                [:triple/vec [[:ax/prefix-iri :foo/y]
+                                              [:ax/rdf-type :a]
+                                              [:ax/str-lit "MyType"]]]]]]]]]]
            (s/conform us/delete-data-update-spec
                       '{:delete-data [[:graph
                                        "<http://example.org>"
-                                       [[:foo/x :dc/title "Title"]]]]})))
+                                       [[:foo/x :dc/title "Title"]
+                                        [:foo/y :a "MyType"]]]]})))
     (is (= '[[:move [:update/default-graph :default]]
              [:to [:update/named-graph [:ax/iri "<http://example.org>"]]]]
            (s/conform us/move-update-spec

--- a/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/aggregate_test.cljc
@@ -12,7 +12,7 @@
       (is (= []
              (vv/group-by-projected-vars
               '[:group-by
-                [[:mod/expr [:expr/terminal [:ax/var ?x]]]]])))
+                [[:mod/group-expr [:expr/terminal [:ax/var ?x]]]]])))
       (is (= '[?x ?y ?z]
              (vv/group-by-projected-vars
               '[:group-by

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -3,7 +3,8 @@
             [clojure.spec.alpha :as s]
             [com.yetanalytics.flint.validate :as v]
             [com.yetanalytics.flint.validate.prefix :as vp]
-            [com.yetanalytics.flint.spec.query :as qs]))
+            [com.yetanalytics.flint.spec.query :as qs]
+            [com.yetanalytics.flint.spec.update :as us]))
 
 (def query '{:prefixes {:foo "<http://foo.org/>"}
              :select [?x]
@@ -45,4 +46,20 @@
            (->> query
                 (s/conform qs/query-spec)
                 v/collect-nodes
-                (vp/validate-prefixes (:prefixes query)))))))
+                (vp/validate-prefixes (:prefixes query)))))
+    (is (= [{:iri :baz/Qux
+             :prefix :baz
+             :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
+             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/nform :triple/spo :triple/po :triple/o :ax/prefix-iri]}
+            {:iri :baz/Quu
+             :prefix :baz
+             :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
+             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/vec :ax/prefix-iri]}]
+           (->>
+            {:prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
+             :insert-data [[:graph "<http://foo.org>"
+                            [{"<http://bar.org>" {:rdf/type #{:baz/Qux}}}
+                             ["<http://bar.org>" :rdf/type :baz/Quu]]]]}
+            (s/conform us/update-spec)
+            v/collect-nodes
+            (vp/validate-prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}))))))


### PR DESCRIPTION
Fix a number of bugs discovered in v0.1.0:
- Allow IRIs and prefixed IRIs to be used in expressions.
- Zipper traversal for validation did not work correctly with deletion/insertion quads.
- `java.time.Instant` instances could not be formatted correctly.
- `a` was not valid in DELETE or INSERT queries.
- Incorrect predicate specs for no-variable-nor-blank-node triples.
- Parentheses were not added around negated property paths.
- Automatically add parens around expressions if needed (e.g. with FILTER).

Also applied updates to the documentation:
- The documentation on the `CONSTRUCT WHERE` query was incorrect.
- General grammar and cleanup fixes.