### PR TITLE
Use multi-specs

### DIFF
--- a/doc/expr.md
+++ b/doc/expr.md
@@ -202,8 +202,6 @@ GROUP_CONCAT(DISTINCT ?y; SEPARATOR = ";")
 
 **NOTE:** Using aggregates in an invalid clause, e.g. a `FILTER` clause, will cause a spec error.
 
-**NOTE:** Using aggregates inside another aggregate will cause a spec error. (Nesting aggregates inside non-aggregate expressions, or vice versa, is perfectly fine, however.)
-
 **NOTE:** Using aggregates in a `SELECT` query, or including a `GROUP BY` in the query, introduces aggregate restrictions on the `SELECT` clause. See the [SPARQL Queries](query.md) page for more details.
 
 ## Custom Functions

--- a/doc/expr.md
+++ b/doc/expr.md
@@ -202,6 +202,8 @@ GROUP_CONCAT(DISTINCT ?y; SEPARATOR = ";")
 
 **NOTE:** Using aggregates in an invalid clause, e.g. a `FILTER` clause, will cause a spec error.
 
+**NOTE:** Using aggregates inside another aggregate will cause a spec error. (Nesting aggregates inside non-aggregate expressions, or vice versa, is perfectly fine, however.)
+
 **NOTE:** Using aggregates in a `SELECT` query, or including a `GROUP BY` in the query, introduces aggregate restrictions on the `SELECT` clause. See the [SPARQL Queries](query.md) page for more details.
 
 ## Custom Functions

--- a/src/dev/com/yetanalytics/flint/sparql.clj
+++ b/src/dev/com/yetanalytics/flint/sparql.clj
@@ -39,6 +39,10 @@
 
 (comment
   (QueryFactory/create
+   "SELECT ((AVG(MAX(?x)) + 1) AS ?avg)
+    WHERE { ?x ?y ?z . }")
+  
+  (QueryFactory/create
    "SELECT (SUM(?x + ?y) AS ?sum) (str(?sum) AS ?z2)
     WHERE {
       ?x ?y ?z .

--- a/src/main/com/yetanalytics/flint/format/where.cljc
+++ b/src/main/com/yetanalytics/flint/format/where.cljc
@@ -55,5 +55,8 @@
 (defmethod f/format-ast-node :where/values [_ [_ values]]
   (str "VALUES " values))
 
+(defmethod f/format-ast-node :where/special [_ [_ where-form]]
+  where-form)
+
 (defmethod f/format-ast-node :where [_ [_ where]]
   (str "WHERE " where))

--- a/src/main/com/yetanalytics/flint/spec/expr.cljc
+++ b/src/main/com/yetanalytics/flint/spec/expr.cljc
@@ -3,7 +3,8 @@
             [clojure.set :as cset]
             [com.yetanalytics.flint.spec.axiom :as ax])
   #?(:cljs (:require-macros
-            [com.yetanalytics.flint.spec.expr :refer [keyword-args]])))
+            [com.yetanalytics.flint.spec.expr :refer [defexprspecs
+                                                      keyword-args]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Terminals

--- a/src/main/com/yetanalytics/flint/spec/expr.cljc
+++ b/src/main/com/yetanalytics/flint/spec/expr.cljc
@@ -54,14 +54,13 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (def nilary-ops
-  #{'rand 'now 'uuid 'struuid 'bnode})
+  #{'rand 'now 'uuid 'struuid})
 
 (def nilary-or-unary-ops
   #{'bnode})
 
 (def unary-ops
-  #{'bnode
-    'not
+  #{'not
     'str 'strlen 'ucase 'lcase
     'lang 'datatype 'blank? 'literal? 'numeric?
     'iri 'uri 'iri? 'uri? 'encode-for-uri
@@ -70,20 +69,6 @@
     'hours 'minutes 'seconds
     'timezone 'tz
     'md5 'sha1 'sha256 'sha384 'sha512})
-
-(def aggregate-expr-ops
-  #{'sum 'min 'max 'avg 'sample})
-
-(def aggregate-expr-or-wild-ops
-  #{'count})
-
-(def aggregate-expr-with-sep-ops
-  #{'group-concat})
-
-(def aggregate-ops
-  (cset/union aggregate-expr-ops
-              aggregate-expr-or-wild-ops
-              aggregate-expr-with-sep-ops))
 
 (def unary-var-ops
   #{'bound})
@@ -114,6 +99,22 @@
 
 (def varardic-ops
   #{'concat 'coalesce})
+
+;; Aggregates
+
+(def aggregate-expr-ops
+  #{'sum 'min 'max 'avg 'sample})
+
+(def aggregate-expr-or-wild-ops
+  #{'count})
+
+(def aggregate-expr-with-sep-ops
+  #{'group-concat})
+
+(def aggregate-ops
+  (cset/union aggregate-expr-ops
+              aggregate-expr-or-wild-ops
+              aggregate-expr-with-sep-ops))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Branch Specs
@@ -277,6 +278,10 @@
 (def expr-multi-spec
   (s/multi-spec expr-spec first))
 
+(comment
+  (s/explain expr-multi-spec '(bnode))
+  (s/explain expr-multi-spec '(zoo-wee-mama)))
+
 ;; Aggregate Expressions
 
 (defmulti agg-expr-spec expr-spec-dispatch)
@@ -297,7 +302,7 @@
 (defexprspecs agg-expr-spec aggregate-expr-or-wild-ops aggregate-wildcard-spec)
 (defexprspecs agg-expr-spec aggregate-expr-with-sep-ops aggregate-separator-spec)
 
-(defmethod expr-spec :custom [_] aggregate-custom-fn-spec)
+(defmethod agg-expr-spec :custom [_] aggregate-custom-fn-spec)
 
 (def agg-expr-multi-spec
   (s/multi-spec agg-expr-spec first))

--- a/src/main/com/yetanalytics/flint/spec/expr.cljc
+++ b/src/main/com/yetanalytics/flint/spec/expr.cljc
@@ -43,6 +43,9 @@
           kvs))
 
 (defmacro keyword-args
+  "Given `kspecs` (e.g. `(keyword-args ::distinct? ::selector)`), return
+   a regex spec that can be used to spec a sequence of `:keyword value`
+   pairs (e.g. `(:distinct? true :selector \";\")`)."
   [& kspecs]
   `(s/& (s/* (s/cat :expr/k keyword? :expr/v any?))
         (s/conformer kvs->map)
@@ -113,6 +116,7 @@
   #{'group-concat})
 
 (def aggregate-ops
+  "A set of all operations used in aggregate expressions."
   (cset/union aggregate-expr-ops
               aggregate-expr-or-wild-ops
               aggregate-expr-with-sep-ops))
@@ -259,7 +263,9 @@
       (s/valid? ax/iri-spec op) :custom)))
 
 ;; No Aggregate Expressions
-(defmulti expr-spec-mm expr-spec-dispatch)
+(defmulti expr-spec-mm
+  "Given a Flint expr list, returns a spec determined by its first arg."
+  expr-spec-dispatch)
 
 (defexprspecs expr-spec-mm nilary-ops nilary-spec)
 (defexprspecs expr-spec-mm nilary-or-unary-ops nilary-or-unary-spec)
@@ -281,7 +287,9 @@
 
 ;; Aggregate Expressions
 
-(defmulti agg-expr-spec-mm expr-spec-dispatch)
+(defmulti agg-expr-spec-mm
+  "Like `expr-spec-mm`, but covers also covers aggregate expressions."
+  expr-spec-dispatch)
 
 (defexprspecs agg-expr-spec-mm nilary-ops nilary-spec)
 (defexprspecs agg-expr-spec-mm nilary-or-unary-ops nilary-or-unary-agg-spec)
@@ -309,6 +317,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- conform-expr
+  "Conforms the map arg into a
+   `[[:expr/op op] [:expr/args args] [:expr/kwargs kwargs]]` vector."
   [{op     :expr/op
     arg-1  :expr/arg-1
     arg-2  :expr/arg-2

--- a/src/main/com/yetanalytics/flint/spec/expr.cljc
+++ b/src/main/com/yetanalytics/flint/spec/expr.cljc
@@ -104,6 +104,165 @@
 
 ;; Branches
 
+;; BEGIN NEW ;;;;;
+
+(def nilary-spec
+  (s/cat :expr/op symbol?))
+
+(def unary-spec
+  (s/cat :expr/op symbol?
+         :expr/arg-1 ::expr))
+
+(def unary-var-spec
+  (s/cat :expr/op symbol?
+         :expr/arg-1 var-terminal-spec))
+
+(def unary-where-spec
+  (s/cat :expr/op unary-where-ops
+         ;; Fully qualify ns to avoid mutually recursive require
+         :expr/arg-1 :com.yetanalytics.flint.spec.where/where))
+
+(def binary-spec
+  (s/cat :expr/op symbol?
+         :expr/arg-1 ::expr
+         :expr/arg-2 ::expr))
+
+(def binary-plus-spec
+  (s/cat :expr/op symbol?
+         :expr/arg-1 ::expr
+         :expr/vargs (s/+ ::expr)))
+
+(def ternary-spec
+  (s/cat :expr/op symbol?
+         :expr/arg-1 ::expr
+         :expr/arg-2 ::expr
+         :expr/arg-3 ::expr))
+
+(def four-ary-spec
+  (s/cat :expr/op symbol?
+         :expr/arg-1 ::expr
+         :expr/arg-2 ::expr
+         :expr/arg-3 ::expr
+         :expr/arg-4 ::expr))
+
+(def varardic-spec
+  (s/cat :expr/op symbol?
+         :expr/vargs (s/* ::expr)))
+
+(def custom-fn-spec
+  (s/cat :expr/op ax/iri-spec
+         :expr/vargs (s/* ::expr)))
+
+(defmulti expr-spec
+  (fn [e]
+    (let [op (first e)]
+      (cond
+        (symbol? op) op
+        (s/valid? ax/iri-spec op) :custom))))
+
+(defmethod expr-spec 'rand [_] nilary-spec)
+(defmethod expr-spec 'now [_] nilary-spec)
+(defmethod expr-spec 'uuid [_] nilary-spec)
+(defmethod expr-spec 'struuid [_] nilary-spec)
+
+(defmethod expr-spec 'bnode [_] (s/and (s/or :nilary nilary-spec
+                                             :unary unary-spec)
+                                       (s/conformer second)))
+
+(defmethod expr-spec 'not [_] unary-spec)
+
+(defmethod expr-spec 'str [_] unary-spec)
+(defmethod expr-spec 'strlen [_] unary-spec)
+(defmethod expr-spec 'ucase [_] unary-spec)
+(defmethod expr-spec 'lcase [_] unary-spec)
+(defmethod expr-spec 'lang [_] unary-spec)
+(defmethod expr-spec 'datatype [_] unary-spec)
+
+(defmethod expr-spec 'blank? [_] unary-spec)
+(defmethod expr-spec 'literal? [_] unary-spec)
+(defmethod expr-spec 'numeric? [_] unary-spec)
+(defmethod expr-spec 'iri? [_] unary-spec)
+(defmethod expr-spec 'uri? [_] unary-spec)
+
+(defmethod expr-spec 'iri [_] unary-spec)
+(defmethod expr-spec 'uri [_] unary-spec)
+(defmethod expr-spec 'encode-for-uri [_] unary-spec)
+
+(defmethod expr-spec 'abs [_] unary-spec)
+(defmethod expr-spec 'ceil [_] unary-spec)
+(defmethod expr-spec 'floor [_] unary-spec)
+(defmethod expr-spec 'round [_] unary-spec)
+
+(defmethod expr-spec 'year [_] unary-spec)
+(defmethod expr-spec 'month [_] unary-spec)
+(defmethod expr-spec 'day [_] unary-spec)
+(defmethod expr-spec 'hours [_] unary-spec)
+(defmethod expr-spec 'minutes [_] unary-spec)
+(defmethod expr-spec 'seconds [_] unary-spec)
+(defmethod expr-spec 'timezone [_] unary-spec)
+(defmethod expr-spec 'tz [_] unary-spec)
+
+(defmethod expr-spec 'md5 [_] unary-spec)
+(defmethod expr-spec 'sha1 [_] unary-spec)
+(defmethod expr-spec 'sha256 [_] unary-spec)
+(defmethod expr-spec 'sha384 [_] unary-spec)
+(defmethod expr-spec 'sha512 [_] unary-spec)
+
+(defmethod expr-spec 'bound [_] unary-var-spec)
+
+(defmethod expr-spec 'exists [_] unary-where-spec)
+(defmethod expr-spec 'not-exists [_] unary-where-spec)
+
+(defmethod expr-spec 'lang-matches [_] binary-spec)
+(defmethod expr-spec 'contains [_] binary-spec)
+(defmethod expr-spec 'strlang [_] binary-spec)
+(defmethod expr-spec 'strdt [_] binary-spec)
+(defmethod expr-spec 'strstarts [_] binary-spec)
+(defmethod expr-spec 'strends [_] binary-spec)
+(defmethod expr-spec 'strbefore [_] binary-spec)
+(defmethod expr-spec 'strafter [_] binary-spec)
+(defmethod expr-spec 'sameterm [_] binary-spec)
+
+(defmethod expr-spec '= [_] binary-spec)
+(defmethod expr-spec 'not= [_] binary-spec)
+(defmethod expr-spec '< [_] binary-spec)
+(defmethod expr-spec '> [_] binary-spec)
+(defmethod expr-spec '<= [_] binary-spec)
+(defmethod expr-spec '>= [_] binary-spec)
+
+(defmethod expr-spec 'and [_] binary-plus-spec)
+(defmethod expr-spec 'or [_] binary-plus-spec)
+(defmethod expr-spec 'in [_] binary-plus-spec)
+(defmethod expr-spec 'not-in [_] binary-plus-spec)
+(defmethod expr-spec '+ [_] binary-plus-spec)
+(defmethod expr-spec '- [_] binary-plus-spec)
+(defmethod expr-spec '* [_] binary-plus-spec)
+(defmethod expr-spec '/ [_] binary-plus-spec)
+
+(defmethod expr-spec 'if [_] ternary-spec)
+
+(defmethod expr-spec 'regex [_] (s/and (s/or :binary binary-spec
+                                             :ternary ternary-spec)
+                                       (s/conformer second)))
+
+(defmethod expr-spec 'substr [_] (s/and (s/or :binary binary-spec
+                                              :ternary ternary-spec)
+                                        (s/conformer second)))
+
+(defmethod expr-spec 'replace [_] (s/and (s/or :ternary ternary-spec
+                                               :four-ary four-ary-spec)
+                                         (s/conformer second)))
+
+(defmethod expr-spec 'concat [_] varardic-spec)
+(defmethod expr-spec 'coalesce [_] varardic-spec)
+
+(defmethod expr-spec :custom [_] custom-fn-spec)
+
+;; We're not gentesting so retag is irrelevant
+(s/multi-spec expr-spec identity)
+
+;; END NEW ;;;;;;;
+
 (defn- conform-expr
   [{op     :expr/op
     arg-1  :expr/arg-1

--- a/src/main/com/yetanalytics/flint/spec/expr.cljc
+++ b/src/main/com/yetanalytics/flint/spec/expr.cljc
@@ -123,33 +123,33 @@
 ;; Built-in Expressions
 
 (def nilary-spec
-  (s/cat :expr/op symbol?))
+  (s/cat :expr/op nilary-ops))
 
 (defn- nilary-or-unary-spec* [expr-spec]
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op nilary-or-unary-ops
          :expr/arg-1 (s/? expr-spec)))
 
 (def nilary-or-unary-spec (nilary-or-unary-spec* ::expr))
 (def nilary-or-unary-agg-spec (nilary-or-unary-spec* ::agg-expr))
 
 (defn- unary-spec* [expr-spec]
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op unary-ops
          :expr/arg-1 expr-spec))
 
 (def unary-spec (unary-spec* ::expr))
 (def unary-agg-spec (unary-spec* ::agg-expr))
 
 (def unary-var-spec
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op unary-var-ops
          :expr/arg-1 var-terminal-spec))
 
 (def unary-where-spec
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op unary-where-ops
          ;; Fully qualify ns to avoid mutually recursive require
          :expr/arg-1 :com.yetanalytics.flint.spec.where/where))
 
 (defn- binary-spec* [expr-spec]
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op binary-ops
          :expr/arg-1 expr-spec
          :expr/arg-2 expr-spec))
 
@@ -157,7 +157,7 @@
 (def binary-agg-spec (binary-spec* ::agg-expr))
 
 (defn- binary-plus-spec* [expr-spec]
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op binary-plus-ops
          :expr/arg-1 expr-spec
          :expr/vargs (s/+ expr-spec)))
 
@@ -165,7 +165,7 @@
 (def binary-plus-agg-spec (binary-plus-spec* ::agg-expr))
 
 (defn- binary-or-ternary-spec* [expr-spec]
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op binary-or-ternary-ops
          :expr/arg-1 expr-spec
          :expr/arg-2 expr-spec
          :expr/arg-3 (s/? expr-spec)))
@@ -174,7 +174,7 @@
 (def binary-or-ternary-agg-spec (binary-or-ternary-spec* ::agg-expr))
 
 (defn- ternary-spec* [expr-spec]
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op ternary-ops
          :expr/arg-1 expr-spec
          :expr/arg-2 expr-spec
          :expr/arg-3 expr-spec))
@@ -183,7 +183,7 @@
 (def ternary-agg-spec (ternary-spec* ::agg-expr))
 
 (defn- ternary-or-fourary-spec* [expr-spec]
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op ternary-or-fourary-ops
          :expr/arg-1 expr-spec
          :expr/arg-2 expr-spec
          :expr/arg-3 expr-spec
@@ -193,7 +193,7 @@
 (def ternary-or-fourary-agg-spec (ternary-or-fourary-spec* ::agg-expr))
 
 (defn- varardic-spec* [expr-spec]
-  (s/cat :expr/op symbol?
+  (s/cat :expr/op varardic-ops
          :expr/vargs (s/* expr-spec)))
 
 (def varardic-spec (varardic-spec* ::expr))
@@ -258,54 +258,50 @@
       (s/valid? ax/iri-spec op) :custom)))
 
 ;; No Aggregate Expressions
-(defmulti expr-spec expr-spec-dispatch)
+(defmulti expr-spec-mm expr-spec-dispatch)
 
-(defexprspecs expr-spec nilary-ops nilary-spec)
-(defexprspecs expr-spec nilary-or-unary-ops nilary-or-unary-spec)
-(defexprspecs expr-spec unary-ops unary-spec)
-(defexprspecs expr-spec unary-var-ops unary-var-spec)
-(defexprspecs expr-spec unary-where-ops unary-where-spec)
-(defexprspecs expr-spec binary-ops binary-spec)
-(defexprspecs expr-spec binary-plus-ops binary-plus-spec)
-(defexprspecs expr-spec binary-or-ternary-ops binary-or-ternary-spec)
-(defexprspecs expr-spec ternary-ops ternary-spec)
-(defexprspecs expr-spec ternary-or-fourary-ops ternary-or-fourary-spec)
-(defexprspecs expr-spec varardic-ops varardic-spec)
+(defexprspecs expr-spec-mm nilary-ops nilary-spec)
+(defexprspecs expr-spec-mm nilary-or-unary-ops nilary-or-unary-spec)
+(defexprspecs expr-spec-mm unary-ops unary-spec)
+(defexprspecs expr-spec-mm unary-var-ops unary-var-spec)
+(defexprspecs expr-spec-mm unary-where-ops unary-where-spec)
+(defexprspecs expr-spec-mm binary-ops binary-spec)
+(defexprspecs expr-spec-mm binary-plus-ops binary-plus-spec)
+(defexprspecs expr-spec-mm binary-or-ternary-ops binary-or-ternary-spec)
+(defexprspecs expr-spec-mm ternary-ops ternary-spec)
+(defexprspecs expr-spec-mm ternary-or-fourary-ops ternary-or-fourary-spec)
+(defexprspecs expr-spec-mm varardic-ops varardic-spec)
 
-(defmethod expr-spec :custom [_] custom-fn-spec)
+(defmethod expr-spec-mm :custom [_] custom-fn-spec)
 
 ;; We're not gentesting so retag is irrelevant
 (def expr-multi-spec
-  (s/multi-spec expr-spec first))
-
-(comment
-  (s/explain expr-multi-spec '(bnode))
-  (s/explain expr-multi-spec '(zoo-wee-mama)))
+  (s/multi-spec expr-spec-mm first))
 
 ;; Aggregate Expressions
 
-(defmulti agg-expr-spec expr-spec-dispatch)
+(defmulti agg-expr-spec-mm expr-spec-dispatch)
 
-(defexprspecs agg-expr-spec nilary-ops nilary-spec)
-(defexprspecs agg-expr-spec nilary-or-unary-ops nilary-or-unary-agg-spec)
-(defexprspecs agg-expr-spec unary-ops unary-agg-spec)
-(defexprspecs agg-expr-spec unary-var-ops unary-var-spec)
-(defexprspecs agg-expr-spec unary-where-ops unary-where-spec)
-(defexprspecs agg-expr-spec binary-ops binary-agg-spec)
-(defexprspecs agg-expr-spec binary-plus-ops binary-plus-agg-spec)
-(defexprspecs agg-expr-spec binary-or-ternary-ops binary-or-ternary-agg-spec)
-(defexprspecs agg-expr-spec ternary-ops ternary-agg-spec)
-(defexprspecs agg-expr-spec ternary-or-fourary-ops ternary-or-fourary-agg-spec)
-(defexprspecs agg-expr-spec varardic-ops varardic-agg-spec)
+(defexprspecs agg-expr-spec-mm nilary-ops nilary-spec)
+(defexprspecs agg-expr-spec-mm nilary-or-unary-ops nilary-or-unary-agg-spec)
+(defexprspecs agg-expr-spec-mm unary-ops unary-agg-spec)
+(defexprspecs agg-expr-spec-mm unary-var-ops unary-var-spec)
+(defexprspecs agg-expr-spec-mm unary-where-ops unary-where-spec)
+(defexprspecs agg-expr-spec-mm binary-ops binary-agg-spec)
+(defexprspecs agg-expr-spec-mm binary-plus-ops binary-plus-agg-spec)
+(defexprspecs agg-expr-spec-mm binary-or-ternary-ops binary-or-ternary-agg-spec)
+(defexprspecs agg-expr-spec-mm ternary-ops ternary-agg-spec)
+(defexprspecs agg-expr-spec-mm ternary-or-fourary-ops ternary-or-fourary-agg-spec)
+(defexprspecs agg-expr-spec-mm varardic-ops varardic-agg-spec)
 
-(defexprspecs agg-expr-spec aggregate-ops aggregate-spec)
-(defexprspecs agg-expr-spec aggregate-expr-or-wild-ops aggregate-wildcard-spec)
-(defexprspecs agg-expr-spec aggregate-expr-with-sep-ops aggregate-separator-spec)
+(defexprspecs agg-expr-spec-mm aggregate-ops aggregate-spec)
+(defexprspecs agg-expr-spec-mm aggregate-expr-or-wild-ops aggregate-wildcard-spec)
+(defexprspecs agg-expr-spec-mm aggregate-expr-with-sep-ops aggregate-separator-spec)
 
-(defmethod agg-expr-spec :custom [_] aggregate-custom-fn-spec)
+(defmethod agg-expr-spec-mm :custom [_] aggregate-custom-fn-spec)
 
 (def agg-expr-multi-spec
-  (s/multi-spec agg-expr-spec first))
+  (s/multi-spec agg-expr-spec-mm first))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Expression Specs

--- a/src/main/com/yetanalytics/flint/spec/modifier.cljc
+++ b/src/main/com/yetanalytics/flint/spec/modifier.cljc
@@ -3,9 +3,8 @@
             [com.yetanalytics.flint.spec.axiom :as ax]
             [com.yetanalytics.flint.spec.expr  :as es]))
 
-;; TODO: Need to restrict `mod/group-expr` to function calls.
-;; However, this may count as a breaking change.
-
+;; Technically a single variable is also an expression, but it's already
+;; distinguished in the context-free grammar so why not also reflect that here.
 (s/def ::group-by
   (s/coll-of (s/or :ax/var          ax/variable?
                    :mod/group-expr  ::es/expr

--- a/src/main/com/yetanalytics/flint/spec/path.cljc
+++ b/src/main/com/yetanalytics/flint/spec/path.cljc
@@ -2,6 +2,10 @@
   (:require [clojure.spec.alpha :as s]
             [com.yetanalytics.flint.spec.axiom :as ax]))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Path Terminal
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 (def path-terminal-spec
   (s/and
    (comp not list?)
@@ -9,38 +13,87 @@
          :ax/prefix-iri ax/prefix-iri?
          :ax/rdf-type   ax/rdf-type?)))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Negated Path
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; A "negated path" (PathNegatedPropertySet in the SPARQL grammar) can
+;; only contain a bunch of alternates of more negated paths.
+
+;; Multi-spec is kind of pointless given that there's only one choice here,
+;; but this makes it symmetrical to the main path spec.
+
+(defmulti path-neg-spec-mm first)
+
+(defmethod path-neg-spec-mm 'alt [_]
+  (s/cat :path/op    #{'alt}
+         :path/paths (s/* ::path-neg)))
+
+(def path-neg-multi-spec
+  (s/multi-spec path-neg-spec-mm identity))
+
 (s/def ::path-neg
   (s/or :path/terminal
         path-terminal-spec
         :path/branch
-        (s/and
-         list?
-         (comp symbol? first)
-         (s/or :path/varardic
-               (s/cat :path/op    #{'alt}
-                      :path/paths (s/* ::path-neg)))
-         (s/conformer second)
-         (s/conformer #(into [] %)))))
+        (s/and list?
+               path-neg-multi-spec
+               ;; Since we never get a singular `:path/path` there is
+               ;; no need for extra conforming.
+               (s/conformer #(into [] %)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Path
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Specs
+
+(def varardic-spec
+  (s/cat :path/op    #{'alt 'cat}
+         :path/paths (s/* ::path)))
+
+(def unary-spec
+  (s/cat :path/op   #{'inv '? '* '+}
+         :path/path ::path))
+
+(def unary-neg-spec
+  (s/cat :path/op   #{'not}
+         :path/path ::path-neg))
+
+;; Multimethods
+;; Note: we could use expr/defexprspec here, but given the limited number of
+;; ops that would be a bit overkill.
+
+(defmulti path-spec-mm first)
+
+(defmethod path-spec-mm 'alt [_] varardic-spec)
+(defmethod path-spec-mm 'cat [_] varardic-spec)
+
+(defmethod path-spec-mm 'inv [_] unary-spec)
+(defmethod path-spec-mm '? [_] unary-spec)
+(defmethod path-spec-mm '* [_] unary-spec)
+(defmethod path-spec-mm '+ [_] unary-spec)
+
+(defmethod path-spec-mm 'not [_] unary-neg-spec)
+
+(def path-multi-spec
+  (s/multi-spec path-spec-mm identity))
+
+;; Putting it all together
+
+(defn- path-conformer
+  "Conform the result of a regex spec by converting any `:path/path` keys
+   into `:path/paths`."
+  [{op    :path/op
+    path  :path/path
+    paths :path/paths}]
+  [[:path/op op]
+   [:path/paths (if path [path] paths)]])
 
 (s/def ::path
   (s/or :path/terminal
         path-terminal-spec
         :path/branch
-        (s/and
-         list?
-         (comp symbol? first)
-         (s/or :path/varardic
-               (s/cat :path/op    #{'alt 'cat}
-                      :path/paths (s/* ::path))
-               :path/unary
-               (s/cat :path/op   #{'inv '? '* '+}
-                      :path/path ::path)
-               :path/unary-neg
-               (s/cat :path/op   #{'not}
-                      :path/path ::path-neg))
-         (s/conformer second)
-         (s/conformer (fn [{op    :path/op
-                            path  :path/path
-                            paths :path/paths}]
-                        [[:path/op op]
-                         [:path/paths (if path [path] paths)]])))))
+        (s/and list?
+               path-multi-spec
+               (s/conformer path-conformer))))

--- a/src/main/com/yetanalytics/flint/spec/where.cljc
+++ b/src/main/com/yetanalytics/flint/spec/where.cljc
@@ -113,15 +113,16 @@
 (def where-special-form-spec
   "Specs for special WHERE forms/graph patterns, which should be
    of the form `[:keyword ...]`."
-  (s/multi-spec where-special-form-mm first))
+  ;; TODO: Should only allow vectors
+  (s/and coll? (s/multi-spec where-special-form-mm first)))
 
 (s/def ::where
   (s/or :where-sub/select
         ::select
         :where-sub/where
-        (s/coll-of (s/or :triple/vec    ts/triple-vec-spec
-                         :triple/nform  ts/normal-form-spec
-                         :where/special where-special-form-spec)
+        (s/coll-of (s/or :where/special where-special-form-spec
+                         :triple/vec    ts/triple-vec-spec
+                         :triple/nform  ts/normal-form-spec)
                    :min-count 1
                    :kind vector?)
         :where-sub/empty

--- a/src/main/com/yetanalytics/flint/spec/where.cljc
+++ b/src/main/com/yetanalytics/flint/spec/where.cljc
@@ -113,8 +113,7 @@
 (def where-special-form-spec
   "Specs for special WHERE forms/graph patterns, which should be
    of the form `[:keyword ...]`."
-  ;; TODO: Should only allow vectors
-  (s/and coll? (s/multi-spec where-special-form-mm first)))
+  (s/and vector? (s/multi-spec where-special-form-mm first)))
 
 (s/def ::where
   (s/or :where-sub/select

--- a/src/main/com/yetanalytics/flint/spec/where.cljc
+++ b/src/main/com/yetanalytics/flint/spec/where.cljc
@@ -51,49 +51,77 @@
 ;; WHERE clause
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(defmulti where-special-form-mm
+  "Accepts a special WHERE form/graph pattern in the form `[:keyword ...]`
+   and returns the appropriate regex spec. The spec applies an additional
+   conformer in order to allow for identification during formatting."
+  first)
+
+(defmethod where-special-form-mm :where [_] ; recursion
+  (s/& (s/cat :k #{:where}
+              :v ::where)
+       (s/conformer (fn [{:keys [v]}] [:where/recurse v]))))
+
+(defmethod where-special-form-mm :union [_]
+  (s/& (s/cat :k #{:union}
+              :v (s/+ ::where))
+       (s/conformer (fn [{:keys [v]}] [:where/union v]))))
+
+(defmethod where-special-form-mm :optional [_]
+  (s/& (s/cat :k #{:optional}
+              :v ::where)
+       (s/conformer (fn [{:keys [v]}] [:where/optional v]))))
+
+(defmethod where-special-form-mm :minus [_]
+  (s/& (s/cat :k #{:minus}
+              :v ::where)
+       (s/conformer (fn [{:keys [v]}] [:where/minus v]))))
+
+(defmethod where-special-form-mm :graph [_]
+  (s/& (s/cat :k #{:graph}
+              :v1 ax/var-or-iri-spec
+              :v2 ::where)
+       (s/conformer (fn [{:keys [v1 v2]}] [:where/graph [v1 v2]]))))
+
+(defmethod where-special-form-mm :service [_]
+  (s/& (s/cat :k #{:service}
+              :v1 ax/var-or-iri-spec
+              :v2 ::where)
+       (s/conformer (fn [{:keys [v1 v2]}] [:where/service [v1 v2]]))))
+
+(defmethod where-special-form-mm :service-silent [_]
+  (s/& (s/cat :k #{:service-silent}
+              :v1 ax/var-or-iri-spec
+              :v2 ::where)
+       (s/conformer (fn [{:keys [v1 v2]}] [:where/service-silent [v1 v2]]))))
+
+(defmethod where-special-form-mm :filter [_]
+  (s/& (s/cat :k #{:filter}
+              :v ::es/expr)
+       (s/conformer (fn [{:keys [v]}] [:where/filter v]))))
+
+(defmethod where-special-form-mm :bind [_]
+  (s/& (s/cat :k #{:bind}
+              :v ::es/expr-as-var)
+       (s/conformer (fn [{:keys [v]}] [:where/bind v]))))
+
+(defmethod where-special-form-mm :values [_]
+  (s/& (s/cat :k #{:values}
+              :v ::vs/values)
+       (s/conformer (fn [{:keys [v]}] [:where/values v]))))
+
+(def where-special-form-spec
+  "Specs for special WHERE forms/graph patterns, which should be
+   of the form `[:keyword ...]`."
+  (s/multi-spec where-special-form-mm first))
+
 (s/def ::where
   (s/or :where-sub/select
         ::select
         :where-sub/where
-        (s/coll-of (s/or
-                    :triple/vec     ts/triple-vec-spec
-                    :triple/nform   ts/normal-form-spec
-                    :where/recurse  (s/& (s/cat :k #{:where}
-                                                :v ::where)
-                                         (s/conformer #(:v %)))
-                    :where/union    (s/& (s/cat :k #{:union}
-                                                :v (s/+ ::where))
-                                         (s/conformer #(:v %)))
-                    :where/optional (s/& (s/cat :k #{:optional}
-                                                :v ::where)
-                                         (s/conformer #(:v %)))
-                    :where/minus    (s/& (s/cat :k #{:minus}
-                                                :v ::where)
-                                         (s/conformer #(:v %)))
-                    :where/graph    (s/& (s/cat :k #{:graph}
-                                                :v1 ax/var-or-iri-spec
-                                                :v2 ::where)
-                                         (s/conformer
-                                          (fn [x] [(:v1 x) (:v2 x)])))
-                    :where/service  (s/& (s/cat :k #{:service}
-                                                :v1 ax/var-or-iri-spec
-                                                :v2 ::where)
-                                         (s/conformer
-                                          (fn [x] [(:v1 x) (:v2 x)])))
-                    :where/service-silent (s/& (s/cat :k #{:service-silent}
-                                                      :v1 ax/var-or-iri-spec
-                                                      :v2 ::where)
-                                               (s/conformer
-                                                (fn [x] [(:v1 x) (:v2 x)])))
-                    :where/filter   (s/& (s/cat :k #{:filter}
-                                                :v ::es/expr)
-                                         (s/conformer #(:v %)))
-                    :where/bind     (s/& (s/cat :k #{:bind}
-                                                :v ::es/expr-as-var)
-                                         (s/conformer #(:v %)))
-                    :where/values   (s/& (s/cat :k #{:values}
-                                                :v ::vs/values)
-                                         (s/conformer #(:v %))))
+        (s/coll-of (s/or :triple/vec    ts/triple-vec-spec
+                         :triple/nform  ts/normal-form-spec
+                         :where/special where-special-form-spec)
                    :min-count 1
                    :kind vector?)
         :where-sub/empty

--- a/src/main/com/yetanalytics/flint/validate/bnode.cljc
+++ b/src/main/com/yetanalytics/flint/validate/bnode.cljc
@@ -28,7 +28,7 @@
 (defn- bgp-divider?
   [ast-node]
   (and (-> ast-node (get-in [0]) (= :where/special))
-       (-> ast-node (get-in [0 1]) (not= :where/filter))))
+       (-> ast-node (get-in [1 0]) (not= :where/filter))))
 
 (defn- get-bgp-index
   "The BGP path is the regular zip loc path appended with an index that

--- a/src/main/com/yetanalytics/flint/validate/bnode.cljc
+++ b/src/main/com/yetanalytics/flint/validate/bnode.cljc
@@ -2,11 +2,6 @@
   (:require [clojure.set :as cset]
             [clojure.zip :as zip]))
 
-(def bgp-dividers
-  #{:where/recurse :where/union :where/optional
-    :where/minus :where/graph :where/service
-    :where/service-silent :where/bind :where/values})
-
 (defn- get-parent-loc
   "Given a bnode's loc, return its parent (either a `:triple/vec`
    or `:triple/nform` node)."
@@ -30,22 +25,29 @@
           zip/up ; [:triple/nform ...]
           ))))
 
+(defn- bgp-divider?
+  [ast-node]
+  (and (-> ast-node (get-in [0]) (= :where/special))
+       (-> ast-node (get-in [0 1]) (not= :where/filter))))
+
 (defn- get-bgp-index
   "The BGP path is the regular zip loc path appended with an index that
    corresponds to that of the BGP in the WHERE vector. For example:
    
-     [:triple/vec ...]     => 0
-     [:triple/nform ...]   => 0
-     [:where/filter ...]   => 0 ; FILTERs don't divide BGPs
-     [:where/optional ...] => X ; BGP divider
-     [:triple/nform ...]   => 1
+     [:triple/vec ...]       => 0
+     [:triple/nform ...]     => 0
+     [:where/special
+      [:where/filter ...]]   => 0 ; FILTERs don't divide BGPs
+     [:where/special
+      [:where/optional ...]] => X ; BGP divider
+     [:triple/nform ...]     => 1
    
    Note that this only works with locs that are immediate children
    of `:where-sub/where` nodes.
    "
   [loc]
   (let [lefts (zip/lefts loc)]
-    (count (filter (fn [[k _]] (bgp-dividers k)) lefts))))
+    (count (filter bgp-divider? lefts))))
 
 (defn- get-where-index
   [pnode nnode]

--- a/src/main/com/yetanalytics/flint/validate/scope.cljc
+++ b/src/main/com/yetanalytics/flint/validate/scope.cljc
@@ -22,10 +22,12 @@
    :path       (conj (->> zip-loc zip/path (mapv first)) k)})
 
 (defn- validate-bind
-  "Validate `BIND (expr AS var)`"
+  "Validate `BIND (expr AS var)` in WHERE clauses."
   [[_expr-as-var-k [_ v-kv]] loc]
   (let [[_ bind-var] v-kv
-        prev-elems   (zip/lefts loc)
+        prev-elems   (-> loc
+                         zip/up ; :where/special
+                         zip/lefts)
         scope        (set (mapcat vv/get-scope-vars prev-elems))]
     (when (contains? scope bind-var)
       (in-scope-err-map bind-var scope loc :where/bind))))

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -133,6 +133,9 @@
 
 ;; Group
 
+(defmethod get-scope-vars :where/special [[_ vs]]
+  (get-scope-vars vs))
+
 (defmethod get-scope-vars :where/recurse [[_ vs]]
   (get-scope-vars vs))
 

--- a/src/test/com/yetanalytics/flint/format/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/where_test.cljc
@@ -58,59 +58,71 @@
                                   [:triple/po [[[:ax/var ?p2]
                                                 [:triple/o [[:ax/var ?o2a]
                                                             [:ax/var ?o2b]]]]]]]]]]
-                  [:where/recurse
-                   [:where-sub/where
-                    [[:triple/vec [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]
-                  [:where/union
-                   [[:where-sub/where
-                     [[:triple/vec
-                       [[:ax/var ?s4] [:ax/var ?p4] [:ax/var ?o4]]]]]
+                  [:where/special
+                   [:where/recurse
                     [:where-sub/where
-                     [[:triple/vec [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]
-                  [:where/optional
-                   [:where-sub/where
-                    [[:triple/vec [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]
-                  [:where/minus
-                   [:where-sub/where
-                    [[:triple/vec [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]
-                  [:where/graph
-                   [[:ax/prefix-iri :ns/my-graph]
+                     [[:triple/vec [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]]
+                  [:where/special
+                   [:where/union
+                    [[:where-sub/where
+                      [[:triple/vec
+                        [[:ax/var ?s4] [:ax/var ?p4] [:ax/var ?o4]]]]]
+                     [:where-sub/where
+                      [[:triple/vec [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]
+                  [:where/special
+                   [:where/optional
                     [:where-sub/where
-                     [[:triple/vec [[:ax/var ?s8] [:ax/var ?p8] [:ax/var ?o8]]]]]]]
-                  [:where/service
-                   [[:ax/prefix-iri :ns/my-uri]
+                     [[:triple/vec [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]]
+                  [:where/special
+                   [:where/minus
                     [:where-sub/where
-                     [[:triple/vec [[:ax/var ?s9] [:ax/var ?p9] [:ax/var ?o9]]]]]]]
-                  [:where/service-silent
-                   [[:ax/prefix-iri :ns/my-uri]
-                    [:where-sub/where
-                     [[:triple/vec [[:ax/var ?s10] [:ax/var ?p10] [:ax/var ?o10]]]]]]]
-                  [:where/bind
-                   [:expr/as-var
-                    [[:expr/branch
-                      [[:expr/op +]
-                       [:expr/args
-                        ([:expr/terminal [:ax/num-lit 2]]
-                         [:expr/terminal [:ax/num-lit 2]])]]]
-                     [:ax/var ?foo]]]]
-                  [:where/filter
-                   [:expr/branch
-                    [[:expr/op not]
-                     [:expr/args
-                      ([:expr/terminal [:ax/bool-lit false]])]]]]
-                  [:where/filter
-                   [:expr/branch
-                    [[:expr/op =]
-                     [:expr/args
-                      ([:expr/terminal [:ax/num-lit 2]]
-                       [:expr/terminal [:ax/var ?bar]])]]]]
-                  [:where/filter
-                   [:expr/branch
-                    [[:expr/op ns:myfn]
-                     [:expr/args
-                      ([:expr/terminal [:ax/num-lit 2]]
-                       [:expr/terminal [:ax/var ?baz]])]]]]
-                  [:where/values
-                   [:values/map [[[:ax/var ?x] [:ax/var ?y]]
-                                 [[[:ax/num-lit 1] [:ax/num-lit 2]]]]]]]]
+                     [[:triple/vec [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]]
+                  [:where/special
+                   [:where/graph
+                    [[:ax/prefix-iri :ns/my-graph]
+                     [:where-sub/where
+                      [[:triple/vec [[:ax/var ?s8] [:ax/var ?p8] [:ax/var ?o8]]]]]]]]
+                  [:where/special
+                   [:where/service
+                    [[:ax/prefix-iri :ns/my-uri]
+                     [:where-sub/where
+                      [[:triple/vec [[:ax/var ?s9] [:ax/var ?p9] [:ax/var ?o9]]]]]]]]
+                  [:where/special
+                   [:where/service-silent
+                    [[:ax/prefix-iri :ns/my-uri]
+                     [:where-sub/where
+                      [[:triple/vec [[:ax/var ?s10] [:ax/var ?p10] [:ax/var ?o10]]]]]]]]
+                  [:where/special
+                   [:where/bind
+                    [:expr/as-var
+                     [[:expr/branch
+                       [[:expr/op +]
+                        [:expr/args
+                         ([:expr/terminal [:ax/num-lit 2]]
+                          [:expr/terminal [:ax/num-lit 2]])]]]
+                      [:ax/var ?foo]]]]]
+                  [:where/special
+                   [:where/filter
+                    [:expr/branch
+                     [[:expr/op not]
+                      [:expr/args
+                       ([:expr/terminal [:ax/bool-lit false]])]]]]]
+                  [:where/special
+                   [:where/filter
+                    [:expr/branch
+                     [[:expr/op =]
+                      [:expr/args
+                       ([:expr/terminal [:ax/num-lit 2]]
+                        [:expr/terminal [:ax/var ?bar]])]]]]]
+                  [:where/special
+                   [:where/filter
+                    [:expr/branch
+                     [[:expr/op ns:myfn]
+                      [:expr/args
+                       ([:expr/terminal [:ax/num-lit 2]]
+                        [:expr/terminal [:ax/var ?baz]])]]]]]
+                  [:where/special
+                   [:where/values
+                    [:values/map [[[:ax/var ?x] [:ax/var ?y]]
+                                  [[[:ax/num-lit 1] [:ax/num-lit 2]]]]]]]]]
                (f/format-ast {:pretty? true}))))))

--- a/src/test/com/yetanalytics/flint/spec/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/expr_test.cljc
@@ -74,6 +74,13 @@
       (is (= [:expr/branch [[:expr/op 'count]
                             [:expr/args [[:expr/terminal [:ax/var '?foo]]]]]]
              (s/conform ::es/agg-expr '(count ?foo))))
+      ;; Nested aggregates banned by some impls, but is allowed here
+      (is (= [:expr/branch [[:expr/op 'count]
+                            [:expr/args
+                             [[:expr/branch
+                               [[:expr/op 'avg]
+                                [:expr/args [[:expr/terminal [:ax/var '?foo]]]]]]]]]]
+             (s/conform ::es/agg-expr '(count (avg ?foo)))))
       (is (= [:expr/branch [[:expr/op 'count]
                             [:expr/args [[:expr/terminal [:ax/var '?foo]]]]
                             [:expr/kwargs [[:distinct? true]]]]]

--- a/src/test/com/yetanalytics/flint/spec/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/expr_test.cljc
@@ -1,7 +1,6 @@
 (ns com.yetanalytics.flint.spec.expr-test
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.spec.alpha :as s]
-            [com.yetanalytics.flint.spec.axiom :as ax]
             [com.yetanalytics.flint.spec.expr  :as es]))
 
 (deftest conform-expr-test
@@ -38,6 +37,8 @@
     (is (= [:expr/branch [[:expr/op 'bound]
                           [:expr/args [[:expr/terminal [:ax/var '?foo]]]]]]
            (s/conform ::es/expr '(bound ?foo))))
+    ;; Don't forget to eval the where namespace here!
+    ;; (We can't require it due to circular dependencies)
     (is (= [:expr/branch [[:expr/op 'exists]
                           [:expr/args [[:where-sub/where
                                         [[:triple/vec '[[:ax/var ?s]
@@ -102,6 +103,9 @@
                             [:expr/args [[:expr/terminal [:ax/var '?foo]]]]
                             [:expr/kwargs [[:distinct? true]]]]]
              (s/conform ::es/agg-expr '(:my/fn ?foo :distinct? true))))
+      (is (= [:expr/branch [[:expr/op [:ax/prefix-iri :my/fn]]
+                            [:expr/args [[:expr/terminal [:ax/var '?foo]]]]]]
+             (s/conform ::es/agg-expr '(:my/fn ?foo))))
       (is (s/invalid?
            (s/conform ::es/agg-expr '(count ?foo :bad? true))))
       (is (s/invalid?
@@ -120,103 +124,59 @@
                            :val  '(rand 1)
                            :via  [::es/expr]
                            :in   []}
-                          {:path   [:expr/branch :expr/nilary]
+                          {:path   [:expr/branch 'rand]
                            :reason "Extra input"
                            :pred   `(s/cat :expr/op es/nilary-ops)
                            :val    '(1)
                            :via    [::es/expr]
-                           :in     [1]}
-                          {:path [:expr/branch :expr/custom :expr/op :ax/iri]
-                           :pred `ax/iri?
-                           :val  'rand
-                           :via  [::es/expr]
-                           :in   [0]}
-                          {:path [:expr/branch :expr/custom :expr/op :ax/prefix-iri]
-                           :pred `ax/prefix-iri?
-                           :val  'rand
-                           :via  [::es/expr]
-                           :in   [0]}]
+                           :in     [1]}]
             ::s/spec     ::es/expr
             ::s/value    '(rand 1)}
-           (-> (s/explain-data ::es/expr '(rand 1))
-               (update ::s/problems (partial filter #(-> % :path last (not= :expr/op)))))))
+           (s/explain-data ::es/expr '(rand 1))))
     (is (= {::s/problems [{:path [:expr/terminal]
                            :pred `(comp not list?)
                            :val  '(not false true)
                            :via  [::es/expr]
                            :in   []}
-                          {:path   [:expr/branch :expr/unary]
+                          {:path   [:expr/branch 'not]
                            :reason "Extra input"
                            :pred   `(s/cat
                                      :expr/op es/unary-ops
-                                     :expr/arg-1 ::es/expr)
+                                     :expr/arg-1 ~'expr-spec)
                            :val    '(true)
                            :via    [::es/expr]
-                           :in     [2]}
-                           {:path [:expr/branch :expr/custom :expr/op :ax/iri]
-                            :pred `ax/iri?
-                            :val  'not
-                            :via  [::es/expr]
-                            :in   [0]}
-                           {:path [:expr/branch :expr/custom :expr/op :ax/prefix-iri]
-                            :pred `ax/prefix-iri?
-                            :val  'not
-                            :via  [::es/expr]
-                            :in   [0]}]
+                           :in     [2]}]
             ::s/spec ::es/expr
             ::s/value '(not false true)}
-           (-> (s/explain-data ::es/expr '(not false true))
-               (update ::s/problems (partial filter #(-> % :path last (not= :expr/op)))))))
+           (s/explain-data ::es/expr '(not false true))))
     (is (= {::s/problems [{:path [:expr/terminal]
                            :pred `(comp not list?)
                            :val  '(contains "foo")
                            :via  [::es/expr]
                            :in   []}
-                          {:path   [:expr/branch :expr/binary :expr/arg-2]
+                          {:path   [:expr/branch 'contains :expr/arg-2]
                            :reason "Insufficient input"
-                           :pred   ::es/expr
+                           :pred   'expr-spec
                            :val    ()
                            :via    [::es/expr ::es/expr]
-                           :in     []}
-                          {:path [:expr/branch :expr/custom :expr/op :ax/iri]
-                           :pred `ax/iri?
-                           :val  'contains
-                           :via  [::es/expr]
-                           :in   [0]}
-                          {:path [:expr/branch :expr/custom :expr/op :ax/prefix-iri]
-                           :pred `ax/prefix-iri?
-                           :val  'contains
-                           :via  [::es/expr]
-                           :in   [0]}]
+                           :in     []}]
             ::s/spec ::es/expr
             ::s/value '(contains "foo")}
-           (-> (s/explain-data ::es/expr '(contains "foo"))
-               (update ::s/problems (partial filter #(-> % :path last (not= :expr/op)))))))
+           (s/explain-data ::es/expr '(contains "foo"))))
     (is (= {::s/problems [{:path [:expr/terminal]
                            :pred `(comp not list?)
                            :val  '(+)
                            :via  [::es/expr]
                            :in   []}
-                          {:path   [:expr/branch :expr/binary-plus :expr/arg-1]
+                          {:path   [:expr/branch '+ :expr/arg-1]
                            :reason "Insufficient input"
-                           :pred   ::es/expr
+                           :pred   'expr-spec
                            :val    ()
                            :via    [::es/expr ::es/expr]
-                           :in     []}
-                          {:path [:expr/branch :expr/custom :expr/op :ax/iri]
-                           :pred `ax/iri?
-                           :val  '+
-                           :via  [::es/expr]
-                           :in   [0]}
-                          {:path [:expr/branch :expr/custom :expr/op :ax/prefix-iri]
-                           :pred `ax/prefix-iri?
-                           :val  '+
-                           :via  [::es/expr]
-                           :in   [0]}]
+                           :in     []}]
             ::s/spec ::es/expr
             ::s/value '(+)}
-           (-> (s/explain-data ::es/expr '(+))
-               (update ::s/problems (partial filter #(-> % :path last (not= :expr/op)))))))))
+           (s/explain-data ::es/expr '(+))))))
 
 (deftest conform-expr-as-var-test
   (testing "Conforming expr AS var clauses"

--- a/src/test/com/yetanalytics/flint/spec/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/expr_test.cljc
@@ -37,8 +37,8 @@
     (is (= [:expr/branch [[:expr/op 'bound]
                           [:expr/args [[:expr/terminal [:ax/var '?foo]]]]]]
            (s/conform ::es/expr '(bound ?foo))))
-    ;; Don't forget to eval the where namespace here!
-    ;; (We can't require it due to circular dependencies)
+    ;; Don't forget to eval the com.yetanalytics.flint.spec.where-test ns!
+    ;; (We can't `require` it due to circular dependencies.)
     (is (= [:expr/branch [[:expr/op 'exists]
                           [:expr/args [[:where-sub/where
                                         [[:triple/vec '[[:ax/var ?s]

--- a/src/test/com/yetanalytics/flint/spec/path_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/path_test.cljc
@@ -42,6 +42,15 @@
         '+ '(+ :foo/bar)))
     (testing "branch nesting"
       (is (= [:path/branch
+              [[:path/op 'not]
+               [:path/paths
+                [[:path/branch
+                  [[:path/op 'alt]
+                   [:path/paths
+                    [[:path/terminal [:ax/prefix-iri :foo/bar]]
+                     [:path/terminal [:ax/prefix-iri :bar/baz]]]]]]]]]]
+             (s/conform ::ps/path '(not (alt :foo/bar :bar/baz)))))
+      (is (= [:path/branch
               [[:path/op 'alt]
                [:path/paths
                 [[:path/branch
@@ -89,11 +98,12 @@
                            :val  '(:foo :bar/baz)
                            :via  [::ps/path]
                            :in   []}
-                          {:path [:path/branch]
-                           :pred `(comp symbol? first)
-                           :val  '(:foo :bar/baz)
-                           :via  [::ps/path]
-                           :in   []}]
+                          {:path   [:path/branch :foo]
+                           :pred   `ps/path-spec-mm
+                           :val    '(:foo :bar/baz)
+                           :reason "no method"
+                           :via    [::ps/path]
+                           :in     []}]
             ::s/spec ::ps/path
             ::s/value '(:foo :bar/baz)}
            (s/explain-data ::ps/path '(:foo :bar/baz))))
@@ -102,21 +112,12 @@
                            :val  '(foo :bar/baz)
                            :via  [::ps/path]
                            :in   []}
-                          {:path [:path/branch :path/varardic :path/op]
-                           :pred '#{'cat 'alt}
-                           :val  'foo
-                           :via  [::ps/path]
-                           :in   [0]}
-                          {:path [:path/branch :path/unary :path/op]
-                           :pred '#{'inv '+ '* '?}
-                           :val  'foo
-                           :via  [::ps/path]
-                           :in   [0]}
-                          {:path [:path/branch :path/unary-neg :path/op]
-                           :pred '#{'not}
-                           :val  'foo
-                           :via  [::ps/path]
-                           :in   [0]}]
+                          {:path   [:path/branch 'foo]
+                           :pred   `ps/path-spec-mm
+                           :val    '(foo :bar/baz)
+                           :reason "no method"
+                           :via    [::ps/path]
+                           :in     []}]
             ::s/spec ::ps/path
             ::s/value '(foo :bar/baz)}
            (s/explain-data ::ps/path '(foo :bar/baz))))
@@ -125,26 +126,17 @@
                            :val  '(not (cat :foo/bar :bar/baz))
                            :via  [::ps/path]
                            :in   []}
-                          {:path [:path/branch :path/varardic :path/op]
-                           :pred '#{'cat 'alt}
-                           :val  'not
-                           :via  [::ps/path]
-                           :in   [0]}
-                          {:path [:path/branch :path/unary :path/op]
-                           :pred '#{'inv '+ '* '?}
-                           :val  'not
-                           :via  [::ps/path]
-                           :in   [0]}
-                          {:path [:path/branch :path/unary-neg :path/path :path/terminal]
-                           :pred `(comp not list?)
-                           :val  '(cat :foo/bar :bar/baz)
-                           :via  [::ps/path ::ps/path-neg ::ps/path-neg]
+                          {:path [:path/branch 'not :path/path :path/terminal],
+                           :pred `(comp not list?),
+                           :val  '(cat :foo/bar :bar/baz),
+                           :via  [::ps/path ::ps/path-neg ::ps/path-neg],
                            :in   [1]}
-                          {:path [:path/branch :path/unary-neg :path/path :path/branch :path/varardic :path/op]
-                           :pred '#{'alt}
-                           :val  'cat
-                           :via  [::ps/path ::ps/path-neg ::ps/path-neg]
-                           :in   [1 0]}]
+                          {:path   [:path/branch 'not :path/path :path/branch 'cat],
+                           :pred   `ps/path-neg-spec-mm,
+                           :val    '(cat :foo/bar :bar/baz),
+                           :reason "no method",
+                           :via    [::ps/path ::ps/path-neg ::ps/path-neg],
+                           :in     [1]}]
             ::s/spec ::ps/path
             ::s/value '(not (cat :foo/bar :bar/baz))}
            (s/explain-data ::ps/path '(not (cat :foo/bar :bar/baz)))))))

--- a/src/test/com/yetanalytics/flint/spec/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/where_test.cljc
@@ -88,7 +88,14 @@
                [:where/values
                 [:values/map [[[:ax/var ?bar] [:ax/var ?qux]]
                               [[[:ax/num-lit 1] [:ax/num-lit 2]]]]]]]]]
-           (s/conform ::ws/where [[:values '{?bar [1] ?qux [2]}]])))))
+           (s/conform ::ws/where [[:values '{?bar [1] ?qux [2]}]])))
+    ;; This is not a special form since it does not conform to the UNION
+    ;; spec (or any other special form spec really)
+    (is (= '[:where-sub/where
+             [[:triple/vec [[:ax/prefix-iri :union]
+                            [:ax/prefix-iri :foo/bar]
+                            [:ax/prefix-iri :baz/qux]]]]]
+           (s/conform ::ws/where '[[:union :foo/bar :baz/qux]])))))
 
 (deftest invalid-where-test
   (testing "invalid WHERE clauses"

--- a/src/test/com/yetanalytics/flint/spec/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/where_test.cljc
@@ -28,56 +28,66 @@
                                    :where    [[?s ?p ?o]]
                                    :group-by [[(+ 2 2) ?foo]]})))
     (is (= '[:where-sub/where
-             [[:where/union
-               [[:where-sub/where
-                 [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
-                  [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]
-                [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]
+             [[:where/special
+               [:where/union
+                [[:where-sub/where
+                  [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
+                   [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]
+                 [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
            (s/conform ::ws/where '[[:union [[?s ?p ?o] [?s ?p ?o]] [[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
-             [[:where/optional
-               [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]
+             [[:where/special
+               [:where/optional
+                [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]
            (s/conform ::ws/where [[:optional '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
-             [[:where/minus
-               [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]
+             [[:where/special
+               [:where/minus
+                [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]
            (s/conform ::ws/where [[:minus '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
-             [[:where/graph
-               [[:ax/prefix-iri :foo/my-graph]
-                [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]
+             [[:where/special
+               [:where/graph
+                [[:ax/prefix-iri :foo/my-graph]
+                 [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
            (s/conform ::ws/where [[:graph :foo/my-graph '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
-             [[:where/service
-               [[:ax/prefix-iri :foo/my-uri]
-                [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]
+             [[:where/special
+               [:where/service
+                [[:ax/prefix-iri :foo/my-uri]
+                 [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
            (s/conform ::ws/where [[:service :foo/my-uri '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
-             [[:where/service-silent
-               [[:ax/prefix-iri :foo/my-uri]
-                [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]
+             [[:where/special
+               [:where/service-silent
+                [[:ax/prefix-iri :foo/my-uri]
+                 [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
            (s/conform ::ws/where [[:service-silent :foo/my-uri '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
-             [[:where/bind
-               [:expr/as-var
-                [[:expr/branch
-                  [[:expr/op +]
-                   [:expr/args
-                    ([:expr/terminal [:ax/num-lit 2]]
-                     [:expr/terminal [:ax/num-lit 2]])]]]
-                 [:ax/var ?foo]]]]]]
+             [[:where/special
+               [:where/bind
+                [:expr/as-var
+                 [[:expr/branch
+                   [[:expr/op +]
+                    [:expr/args
+                     ([:expr/terminal [:ax/num-lit 2]]
+                      [:expr/terminal [:ax/num-lit 2]])]]]
+                  [:ax/var ?foo]]]]]]]
            (s/conform ::ws/where [[:bind '[(+ 2 2) ?foo]]])))
     (is (= '[:where-sub/where
-             [[:where/filter
-               [:expr/branch
-                [[:expr/op =]
-                 [:expr/args
-                  ([:expr/terminal [:ax/num-lit 2]]
-                   [:expr/terminal [:ax/var ?foo]])]]]]]]
+             [[:where/special
+               [:where/filter
+                [:expr/branch
+                 [[:expr/op =]
+                  [:expr/args
+                   ([:expr/terminal [:ax/num-lit 2]]
+                    [:expr/terminal [:ax/var ?foo]])]]]]]]]
            (s/conform ::ws/where [[:filter '(= 2 ?foo)]])))
     (is (= '[:where-sub/where
-             [[:where/values [:values/map [[[:ax/var ?bar] [:ax/var ?qux]]
-                                           [[[:ax/num-lit 1] [:ax/num-lit 2]]]]]]]]
+             [[:where/special
+               [:where/values
+                [:values/map [[[:ax/var ?bar] [:ax/var ?qux]]
+                              [[[:ax/num-lit 1] [:ax/num-lit 2]]]]]]]]]
            (s/conform ::ws/where [[:values '{?bar [1] ?qux [2]}]])))))
 
 (deftest invalid-where-test

--- a/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
@@ -19,16 +19,14 @@
                   :where  [[?x :foo/bar _1]]}
                 (s/conform qs/query-spec)
                 v/collect-nodes
-                vb/validate-bnodes
-                )))
+                vb/validate-bnodes)))
     (is (= [#{'_1} nil]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [?x :foo/bar _1]]}
                 (s/conform qs/query-spec)
                 v/collect-nodes
-                vb/validate-bnodes
-                )))
+                vb/validate-bnodes)))
     (is (= [#{'_1} nil]
            (->> '{:select [?x]
                   :where  [{?x {:foo/bar #{_1}
@@ -37,30 +35,27 @@
                                 :foe/fum #{_1}}}]}
                 (s/conform qs/query-spec)
                 v/collect-nodes
-                vb/validate-bnodes
-                )))
+                vb/validate-bnodes)))
     (is (= [#{'_1 '_2} nil]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]
                            [:where [[?y :baz/qux _2]]]]}
                 (s/conform qs/query-spec)
                 v/collect-nodes
-                vb/validate-bnodes
-                )))
+                vb/validate-bnodes)))
     (is (= [#{} nil]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _]]]
                            [:where [[?y :baz/qux _]]]]}
                 (s/conform qs/query-spec)
                 v/collect-nodes
-                vb/validate-bnodes
-                ))))
+                vb/validate-bnodes))))
   (testing "invalid blank nodes"
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/recurse :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/recurse :where-sub/where 0]}]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]
                            [:where [[?y :baz/qux _1]]]]}
@@ -69,13 +64,13 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/recurse :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/recurse :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/recurse :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/recurse :where-sub/where 0]}]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{?x {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -86,17 +81,17 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1 '_2} {:kind ::vb/dupe-bnodes-bgp
                         :errors [{:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 1 :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
                                  {:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 0 :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 1 :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 1 :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 0 :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 0 :where/recurse :where-sub/where 0]}]}]
+                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{_2 {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -107,7 +102,7 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/optional :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0]}
                              {:bnode '_1
                               :path  [:query/select :where :where-sub/where 0]}]}]
            (->> '{:select [?x]
@@ -118,7 +113,7 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 2 :where/optional :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 2 :where/special :where/optional :where-sub/where 0]}
                              {:bnode '_1
                               :path  [:query/select :where :where-sub/where 0]}
                              {:bnode '_1
@@ -134,7 +129,7 @@
                     :errors [{:bnode '_1
                               :path  [:query/select :where :where-sub/where 1]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/optional :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0]}
                              {:bnode '_1
                               :path  [:query/select :where :where-sub/where 0]}]}]
            (->> '{:select [?x]
@@ -148,7 +143,7 @@
                     :errors [{:bnode '_1
                               :path  [:query/select :where :where-sub/where 0]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/filter :expr/branch :expr/args :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/filter :expr/branch :expr/args :where-sub/where 0]}
                              {:bnode '_1
                               :path  [:query/select :where :where-sub/where 0]}]}]
            (->> '{:select [?x]
@@ -160,7 +155,7 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-update
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/recurse :where-sub/where 0]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]
                     :prev-bnodes #{'_1}}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]]}
@@ -169,7 +164,7 @@
                 (vb/validate-bnodes #{'_1}))))
     (is (= [[#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                      :errors [{:bnode '_1
-                               :path  [:update/modify :where :where-sub/where 0 :where/recurse :where-sub/where 0]}
+                               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}
                               {:bnode '_1
                                :path  [:update/modify :insert]}]}]]
            (->> '[{:insert [[?x :foo/bar _1]]
@@ -193,7 +188,7 @@
              [{:bnode '_1
                :path  [:update/modify :insert]}
               {:bnode '_2
-               :path  [:update/modify :where :where-sub/where 0 :where/recurse :where-sub/where 0]}]
+               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]
              :prev-bnodes
              #{'_1 '_2}}]
            (->> '[{:insert [[?x :foo/bar _1]]

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -38,11 +38,11 @@
             {:iri      :fii/bar
              :prefix   :fii
              :prefixes {:foo "<http://foo.org/>"}
-             :path     [:query/select :where :where-sub/where :where/union :where-sub/where :triple/vec :ax/prefix-iri]}
+             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :triple/vec :ax/prefix-iri]}
             {:iri      :fum/bar
              :prefix   :fum
              :prefixes {:foo "<http://foo.org/>"}
-             :path     [:query/select :where :where-sub/where :where/union :where-sub/where :triple/vec :ax/prefix-iri]}]
+             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :triple/vec :ax/prefix-iri]}]
            (->> query
                 (s/conform qs/query-spec)
                 v/collect-nodes

--- a/src/test/com/yetanalytics/flint/validate/scope_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/scope_test.cljc
@@ -245,7 +245,7 @@
     (is (= [{:kind       ::vs/var-in-scope
              :variable   '?y
              :scope-vars #{'?x '?y '?z}
-             :path       [:query/select :where :where-sub/where :where/bind]}]
+             :path       [:query/select :where :where-sub/where :where/special :where/bind]}]
            (->> '{:select [?x]
                   :where [[?x ?y ?z]
                           [:bind [3 ?y]]]}
@@ -259,7 +259,7 @@
              {:kind       ::vs/var-in-scope
               :variable   '?y
               :scope-vars #{'?x '?y '?z}
-              :path       [:query/select :where :where-sub/where :where/bind]}}
+              :path       [:query/select :where :where-sub/where :where/special :where/bind]}}
            (->> '{:select [?w [2 ?x]]
                   :where [[?x ?y ?z]
                           [:bind [3 ?y]]]}


### PR DESCRIPTION
Use `s/multi-spec` in place of `s/or` in specs with a lot of branching and where values have a clear `(keyword-or-sym ...)` structure, i.e. expressions, property paths, and `WHERE` clauses. This is mainly intended to cut down on the size of spec error messages. (Unfortunately, I was unable to achieve appreciable performance gains, which was my other goal of this change.)

Some changes to be aware of:
- ~Aggregates can no longer be nested inside other aggregates, as it is not allowed by the Apache Jena query parser. (TODO: Double check that this is the case in general and not a Jena-specific detail).~ This change was reverted upon further discussions in the Clojurians slack.
- Minor changes to the AST for WHERE clauses, namely the addition of a `:where/special` node for keyword clauses. This is mainly an internal detail and should not affect spec'ing and formatting.
- WHERE clause `[:keyword ...]` forms must now be vectors. This was always intended to be the case, so any use of non-vectors ought to be considered to be a bug.