### PR TITLE
[PS-455] Implement collections syntactic sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.3.0
+
+- Add support for RDF List syntactic sugar.
+- Add support for blank node vector syntactic sugar.
+- Modify the AST tree for triples to support the new features and to remove redundant nodes in the tree.
+- Rework blank node validation to make the implementation simpler (this results in minor changes to the error output).
+
 ## v0.2.1
 
 - Update GitHub Actions CI and CD to remove deprecation warnings.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you are using Apache Jena, check out the [flint-jena](https://github.com/yeta
 Add the following to your `deps.edn` map.
 
 ```clojure
-com.yetanalytics/flint {:mvn/version "0.2.1"
+com.yetanalytics/flint {:mvn/version "0.3.0"
                         :exclusions [org.clojure/clojure
                                      org.clojure/clojurescript]}
 ```

--- a/dev-resources/test-fixtures/inputs/query/select/select-12.edn
+++ b/dev-resources/test-fixtures/inputs/query/select/select-12.edn
@@ -1,0 +1,3 @@
+;; SELECT with lists
+{:select [?x]
+ :where  [[?s ?p (1 ?x 3 4)]]}

--- a/dev-resources/test-fixtures/inputs/query/select/select-13.edn
+++ b/dev-resources/test-fixtures/inputs/query/select/select-13.edn
@@ -1,0 +1,7 @@
+;; SELECT with blank node vectors
+{:prefixes {:$    "<http://foo.org/>"
+            :foaf "<http://xmlns.com/foaf/0.1/>"}
+ :select   [?x ?name]
+ :where    [[[:p1 "v"] :q1 "w"]
+            [:x :q2 [:p2 "v"]]
+            [[:foaf/name ?name :foaf/mbox "<mailto:bar@example.com>"]]]}

--- a/dev-resources/test-fixtures/inputs/query/select/select-14.edn
+++ b/dev-resources/test-fixtures/inputs/query/select/select-14.edn
@@ -1,4 +1,5 @@
 ;; SELECT with both lists and blank node vectors
 {:prefixes {:$ "<http://foo.org/>"}
  :select   [?x]
- :where    [{(1 [:p :q] (2 ?x)) {}}]}
+ :where    [{(1 [:p :q] (2 ?x)) {}
+             () {:r #{[]}}}]}

--- a/dev-resources/test-fixtures/inputs/query/select/select-14.edn
+++ b/dev-resources/test-fixtures/inputs/query/select/select-14.edn
@@ -1,0 +1,4 @@
+;; SELECT with both lists and blank node vectors
+{:prefixes {:$ "<http://foo.org/>"}
+ :select   [?x]
+ :where    [{(1 [:p :q] (2 ?x)) {}}]}

--- a/dev-resources/test-fixtures/outputs/query/select/select-12.rq
+++ b/dev-resources/test-fixtures/outputs/query/select/select-12.rq
@@ -1,0 +1,4 @@
+SELECT ?x
+WHERE {
+    ?s ?p ( 1 ?x 3 4 ) .
+}

--- a/dev-resources/test-fixtures/outputs/query/select/select-13.rq
+++ b/dev-resources/test-fixtures/outputs/query/select/select-13.rq
@@ -1,0 +1,9 @@
+PREFIX :     <http://foo.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?x ?name
+WHERE {
+    [ :p1 "v" ] :q1 "w" .
+    :x :q2 [ :p2 "v" ] .
+    [ foaf:name ?name ;
+      foaf:mbox <mailto:bar@example.com> ] .
+}

--- a/dev-resources/test-fixtures/outputs/query/select/select-14.rq
+++ b/dev-resources/test-fixtures/outputs/query/select/select-14.rq
@@ -1,0 +1,5 @@
+PREFIX : <http://foo.org/>
+SELECT ?x
+WHERE {
+    ( 1 [ :p :q ] ( 2 ?x ) ) .
+}

--- a/dev-resources/test-fixtures/outputs/query/select/select-14.rq
+++ b/dev-resources/test-fixtures/outputs/query/select/select-14.rq
@@ -2,4 +2,5 @@ PREFIX : <http://foo.org/>
 SELECT ?x
 WHERE {
     ( 1 [ :p :q ] ( 2 ?x ) ) .
+    () :r [] .
 }

--- a/doc/triple.md
+++ b/doc/triple.md
@@ -110,8 +110,6 @@ Objects can be one of the following:
 
 **NOTE:** Technically literals are allowed in subject position according to the SPARQL spec, but no RDF implementation accepts that, so Flint does not allow for subject literals either (unless they are in an RDF list as described below).
 
-**NOTE:** SPARQL has [syntactic sugar](https://www.w3.org/TR/sparql11-query/#collections) for easy writing of RDF lists, but for simplicity that is not implemented in Flint.
-
 ## RDF Lists
 
 Flint supports SPARQL's [syntactic sugar](https://www.w3.org/TR/sparql11-query/#collections) for easy writing of RDF lists. For example:

--- a/doc/triple.md
+++ b/doc/triple.md
@@ -108,9 +108,67 @@ Objects can be one of the following:
 
 **NOTE:** Variables are not allowed in triples in `DELETE DATA` OR `INSERT DATA` clauses.
 
-**NOTE:** Technically literals are allowed in subject position according to the SPARQL spec, but no RDF implementation accepts that, so Flint does not allow for subject literals either.
+**NOTE:** Technically literals are allowed in subject position according to the SPARQL spec, but no RDF implementation accepts that, so Flint does not allow for subject literals either (unless they are in an RDF list as described below).
 
 **NOTE:** SPARQL has [syntactic sugar](https://www.w3.org/TR/sparql11-query/#collections) for easy writing of RDF lists, but for simplicity that is not implemented in Flint.
+
+## RDF Lists
+
+Flint supports SPARQL's [syntactic sugar](https://www.w3.org/TR/sparql11-query/#collections) for easy writing of RDF lists. For example:
+```clojure
+{:select [?x]
+ :where  [[(1 ?x 3 4) ?p ?o]]}
+```
+
+becomes
+```sparql
+SELECT ?x
+WHERE {
+    (1 ?x 3 4) ?p ?o
+}
+```
+which should then expanded out into an RDF list by your SPARQL query engine.
+
+RDF lists be placed in both subject and object position. If they are placed in subject position, then predicates and objects are optional (which is not usually the case). The predicate-object map can be left empty in normal form representation:
+```clojure
+{:select [?x]
+ :where  [{(1 ?x 3 4) {}}]}
+```
+
+and can be left out entirely in triple representation:
+```clojure
+{:select [?x]
+ :where  [[(1 ?x 3 4)]]}
+```
+
+RDF lists can also be nested, both with themselves and with blank node vectors (see below):
+```clojure
+{:select [?x]
+ :where  [[(1 [:p :q] (2))]]}
+```
+
+## Blank Node Vectors
+
+Flint also has support for SPARQL's [blank node syntactic sugar](https://www.w3.org/TR/sparql11-query/#QSynBlankNodes), which will be expanded out by the SPARQL engine. For example:
+
+```clojure
+{:prefixes {:foaf "<http://xmlns.com/foaf/0.1/>"
+ :select   [?name]
+ :where    [{[:foaf/name ?name
+              :foaf/mbox "<mailto:foo@example.org>"] {}}]}}
+```
+
+becomes:
+```sparql
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?name
+WHERE {
+    [ foaf:name ?name
+      foaf:mbox <mailto:foo@example.com> ] .
+}
+```
+
+Note that like with RDF lists, the predicate and object may be omitted here.
 
 ## Property Paths
 

--- a/src/dev/com/yetanalytics/flint/sparql.clj
+++ b/src/dev/com/yetanalytics/flint/sparql.clj
@@ -40,6 +40,31 @@
 
 (comment
   (QueryFactory/create
+   "CONSTRUCT { _:b0 ?pred _:b0 }
+    WHERE { _:b0 ?pred _:b0 .
+            OPTIONAL {
+              ?y ?pred2 _:b1
+            }
+            _:b0 ?question _:b0 . }")
+  
+  (QueryFactory/create
+   "SELECT ?x
+    WHERE {
+      { ?x <http://foo.org> _:1 . }
+      { ?y <http://bar.org> _:1 . }
+    }")
+  
+  (QueryFactory/create
+   "PREFIX foo: <http://foo.org>
+    SELECT ?x WHERE {
+      ?x foo:bar _:1 .
+      FILTER NOT EXISTS { ?z foo:baz ?w . }
+      ?y foo:qux _:1 .
+    }")
+  )
+
+(comment
+  (QueryFactory/create
    "SELECT ((AVG(MAX(?x)) + 1) AS ?avg)
     WHERE { ?x ?y ?z . }")
   

--- a/src/dev/com/yetanalytics/flint/sparql.clj
+++ b/src/dev/com/yetanalytics/flint/sparql.clj
@@ -61,6 +61,11 @@
       FILTER NOT EXISTS { ?z foo:baz ?w . }
       ?y foo:qux _:1 .
     }")
+  
+  (QueryFactory/create
+   "SELECT ?x WHERE {
+      [<http://bar.org#1> [<http://bar.org#2> ?x]] <http://foo.org> \"w\"
+   }")
   )
 
 (comment

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -4,6 +4,12 @@
             [com.yetanalytics.flint.format.axiom]
             [com.yetanalytics.flint.format.path]))
 
+(defmethod f/format-ast-node :triple/object [_ [_ object]]
+  object)
+
+(defmethod f/format-ast-node :triple/list [_ [_ list]]
+  (str "( " (cstr/join " " list) " )"))
+
 (defmethod f/format-ast-node :triple/path [_ [_ path]]
   path)
 

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -11,9 +11,11 @@
   (str "( " (cstr/join " " list) " )"))
 
 (defmethod f/format-ast-node :triple/bnodes [{:keys [pretty?]} [_ po-pairs]]
-  (let [join-sep (if pretty? " ;\n  " " ; ")
-        po-strs  (mapv (fn [[p-str o-str]] (str p-str " " o-str)) po-pairs)]
-    (str "[ " (cstr/join join-sep po-strs) " ]")))
+  (if (empty? po-pairs)
+    "[]" ; Treat as a scalar blank node
+    (let [join-sep (if pretty? " ;\n  " " ; ")
+          po-strs  (mapv (fn [[p-str o-str]] (str p-str " " o-str)) po-pairs)]
+      (str "[ " (cstr/join join-sep po-strs) " ]"))))
 
 (defmethod f/format-ast-node :triple.vec/spo [_ [_ [s-str p-str o-str]]]
   (str s-str " " p-str " " o-str " ."))

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -8,7 +8,9 @@
   path)
 
 (defmethod f/format-ast-node :triple/list [_ [_ list]]
-  (str "( " (cstr/join " " list) " )"))
+  (if (empty? list)
+    "()" ; Special case for empty lists
+    (str "( " (cstr/join " " list) " )")))
 
 (defmethod f/format-ast-node :triple/bnodes [{:keys [pretty?]} [_ po-pairs]]
   (if (empty? po-pairs)

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -10,11 +10,11 @@
 (defmethod f/format-ast-node :triple/path [_ [_ path]]
   path)
 
-(defmethod f/format-ast-node :triple.vec/spo [_ [_ [s p o]]]
-  (str s " " p " " o " ."))
+(defmethod f/format-ast-node :triple.vec/spo [_ [_ [s-str p-str o-str]]]
+  (str s-str " " p-str " " o-str " ."))
 
-(defmethod f/format-ast-node :triple.vec/s [_ [_ [s]]]
-  (str s " ."))
+(defmethod f/format-ast-node :triple.vec/s [_ [_ [s-str]]]
+  (str s-str " ."))
 
 (defn- format-spo-map [spo pretty?]
   (if pretty?
@@ -31,30 +31,30 @@
               (cstr/join " . "))
          " .")))
 
-(defmethod f/format-ast-node :triple.nform/spo [{:keys [pretty?]} [_ spo]]
-  (format-spo-map spo pretty?))
+(defmethod f/format-ast-node :triple.nform/spo [{:keys [pretty?]} [_ spo-strs]]
+  (format-spo-map spo-strs pretty?))
 
-(defmethod f/format-ast-node :triple.nform/s [{:keys [pretty?]} [_ spo]]
-  (format-spo-map spo pretty?))
+(defmethod f/format-ast-node :triple.nform/s [{:keys [pretty?]} [_ s-str]]
+  (format-spo-map s-str pretty?))
 
-(defmethod f/format-ast-node :triple.nform/po [{:keys [pretty?]} [_ po]]
+(defmethod f/format-ast-node :triple.nform/po [{:keys [pretty?]} [_ po-strs]]
   (let [join-sep (if pretty? " ;\n" " ; ")]
-    (->> po
+    (->> po-strs
          (map (fn [[p o]] (str p " " o)))
          (cstr/join join-sep))))
 
-(defmethod f/format-ast-node :triple.nform/o [_ [_ o]]
-  (->> o (cstr/join " , ")))
+(defmethod f/format-ast-node :triple.nform/o [_ [_ o-strs]]
+  (->> o-strs (cstr/join " , ")))
 
 (defn format-quads [quads pretty?]
   (-> quads
       (f/join-clauses pretty?)
       (f/wrap-in-braces pretty?)))
 
-(defmethod f/format-ast-node :triple/quads
-  [_ [_ [var-or-iri triples-str]]]
-  (str "GRAPH " var-or-iri " " triples-str))
+(defmethod f/format-ast-node :triple.quad/gspo
+  [_ [_ [graph-str spo-str]]]
+  (str "GRAPH " graph-str " " spo-str))
 
-(defmethod f/format-ast-node :triple/quad-triples
-  [{:keys [pretty?]} [_ triples]]
-  (format-quads triples pretty?))
+(defmethod f/format-ast-node :triple.quad/spo
+  [{:keys [pretty?]} [_ spo-strs]]
+  (format-quads spo-strs pretty?))

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -4,11 +4,16 @@
             [com.yetanalytics.flint.format.axiom]
             [com.yetanalytics.flint.format.path]))
 
+(defmethod f/format-ast-node :triple/path [_ [_ path]]
+  path)
+
 (defmethod f/format-ast-node :triple/list [_ [_ list]]
   (str "( " (cstr/join " " list) " )"))
 
-(defmethod f/format-ast-node :triple/path [_ [_ path]]
-  path)
+(defmethod f/format-ast-node :triple/bnodes [{:keys [pretty?]} [_ bnodes]]
+  (let [join-sep   (if pretty? " ;\n " " ; ")
+        bnode-strs (map (fn [[pred obj]] (str pred " " obj)) bnodes)]
+    (str "[ " (cstr/join join-sep bnode-strs) " ]")))
 
 (defmethod f/format-ast-node :triple.vec/spo [_ [_ [s-str p-str o-str]]]
   (str s-str " " p-str " " o-str " ."))

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -4,9 +4,6 @@
             [com.yetanalytics.flint.format.axiom]
             [com.yetanalytics.flint.format.path]))
 
-(defmethod f/format-ast-node :triple/object [_ [_ object]]
-  object)
-
 (defmethod f/format-ast-node :triple/list [_ [_ list]]
   (str "( " (cstr/join " " list) " )"))
 

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -16,12 +16,6 @@
 (defmethod f/format-ast-node :triple/vec-no-po [_ [_ [s]]]
   (str s " ."))
 
-(defmethod f/format-ast-node :triple/nform [_ [_ nform]]
-  nform)
-
-(defmethod f/format-ast-node :triple/nform-no-po [_ [_ nform]]
-  nform)
-
 (defn- format-spo-map [spo pretty?]
   (if pretty?
     (str (->> spo
@@ -37,16 +31,19 @@
               (cstr/join " . "))
          " .")))
 
-(defmethod f/format-ast-node :triple/spo [{:keys [pretty?]} [_ spo]]
+(defmethod f/format-ast-node :triple.nform/spo [{:keys [pretty?]} [_ spo]]
   (format-spo-map spo pretty?))
 
-(defmethod f/format-ast-node :triple/po [{:keys [pretty?]} [_ po]]
+(defmethod f/format-ast-node :triple.nform/s [{:keys [pretty?]} [_ spo]]
+  (format-spo-map spo pretty?))
+
+(defmethod f/format-ast-node :triple.nform/po [{:keys [pretty?]} [_ po]]
   (let [join-sep (if pretty? " ;\n" " ; ")]
     (->> po
          (map (fn [[p o]] (str p " " o)))
          (cstr/join join-sep))))
 
-(defmethod f/format-ast-node :triple/o [_ [_ o]]
+(defmethod f/format-ast-node :triple.nform/o [_ [_ o]]
   (->> o (cstr/join " , ")))
 
 (defn format-quads [quads pretty?]

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -19,7 +19,7 @@
 (defmethod f/format-ast-node :triple/nform [_ [_ nform]]
   nform)
 
-(defmethod f/format-ast-node :triple/spo [{:keys [pretty?]} [_ spo]]
+(defn- format-spo-map [spo pretty?]
   (if pretty?
     (str (->> spo
               (map (fn [[s po]]
@@ -33,6 +33,12 @@
               (map (fn [[s po]] (str s " " po)))
               (cstr/join " . "))
          " .")))
+
+(defmethod f/format-ast-node :triple/spo [{:keys [pretty?]} [_ spo]]
+  (format-spo-map spo pretty?))
+
+(defmethod f/format-ast-node :triple/spo-list [{:keys [pretty?]} [_ spo]]
+  (format-spo-map spo pretty?))
 
 (defmethod f/format-ast-node :triple/po [{:keys [pretty?]} [_ po]]
   (let [join-sep (if pretty? " ;\n" " ; ")]

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -16,7 +16,13 @@
 (defmethod f/format-ast-node :triple/vec [_ [_ [s p o]]]
   (str s " " p " " o " ."))
 
+(defmethod f/format-ast-node :triple/vec-no-po [_ [_ [s]]]
+  (str s " ."))
+
 (defmethod f/format-ast-node :triple/nform [_ [_ nform]]
+  nform)
+
+(defmethod f/format-ast-node :triple/nform-no-po [_ [_ nform]]
   nform)
 
 (defn- format-spo-map [spo pretty?]
@@ -35,9 +41,6 @@
          " .")))
 
 (defmethod f/format-ast-node :triple/spo [{:keys [pretty?]} [_ spo]]
-  (format-spo-map spo pretty?))
-
-(defmethod f/format-ast-node :triple/spo-list [{:keys [pretty?]} [_ spo]]
   (format-spo-map spo pretty?))
 
 (defmethod f/format-ast-node :triple/po [{:keys [pretty?]} [_ po]]

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -25,24 +25,22 @@
 (defmethod f/format-ast-node :triple.vec/s [_ [_ [s-str]]]
   (str s-str " ."))
 
+(defn- format-spo-pretty [s-str po-str]
+  (let [indent (->> (repeat (inc (count s-str)) " ")
+                    (cstr/join "")
+                    (str "\n"))]
+    (str s-str " " (cstr/replace po-str #"\n" indent))))
+
+(defn- format-spo [s-str po-str]
+  (str s-str " " po-str))
+
 (defmethod f/format-ast-node :triple.nform/spo [{:keys [pretty?]} [_ spo-pairs]]
-  (if pretty?
+  (let [format-spo (if pretty? format-spo-pretty format-spo)
+        join-sep   (if pretty? " .\n" " . ")]
     (str (->> spo-pairs
               (map (fn [[s-str po-str]]
-                     (let [indent (->> (repeat (inc (count s-str)) " ")
-                                       (cstr/join "")
-                                       (str "\n"))]
-                       (str s-str " " (cstr/replace po-str #"\n" indent)))))
-              (cstr/join " .\n"))
-         " .")
-    (str (->> spo-pairs
-              (map (fn [[s-str po-str]] (str s-str " " po-str)))
-              (cstr/join " . "))
-         " .")))
-
-(defmethod f/format-ast-node :triple.nform/s [{:keys [pretty?]} [_ s-pairs]]
-  (let [join-sep (if pretty? " .\n" " . ")]
-    (str (->> s-pairs (map (fn [[s-str _]] s-str)) (cstr/join join-sep))
+                     (if (empty? po-str) s-str (format-spo s-str po-str))))
+              (cstr/join join-sep))
          " .")))
 
 (defmethod f/format-ast-node :triple.nform/po [{:keys [pretty?]} [_ po-strs]]
@@ -50,6 +48,9 @@
     (->> po-strs
          (map (fn [[p o]] (str p " " o)))
          (cstr/join join-sep))))
+
+(defmethod f/format-ast-node :triple.nform/po-empty [_ _]
+  "")
 
 (defmethod f/format-ast-node :triple.nform/o [_ [_ o-strs]]
   (->> o-strs (cstr/join " , ")))

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -10,10 +10,12 @@
 (defmethod f/format-ast-node :triple/list [_ [_ list]]
   (str "( " (cstr/join " " list) " )"))
 
-(defmethod f/format-ast-node :triple/bnodes [{:keys [pretty?]} [_ bnodes]]
-  (let [join-sep   (if pretty? " ;\n " " ; ")
-        bnode-strs (map (fn [[pred obj]] (str pred " " obj)) bnodes)]
-    (str "[ " (cstr/join join-sep bnode-strs) " ]")))
+(defmethod f/format-ast-node :triple/bnode-pair [_ [_ [p o]]]
+  (str p " " o))
+
+(defmethod f/format-ast-node :triple/bnodes [{:keys [pretty?]} [_ po-strs]]
+  (let [join-sep (if pretty? " ;\n " " ; ")]
+    (str "[ " (cstr/join join-sep po-strs) " ]")))
 
 (defmethod f/format-ast-node :triple.vec/spo [_ [_ [s-str p-str o-str]]]
   (str s-str " " p-str " " o-str " ."))

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -10,10 +10,10 @@
 (defmethod f/format-ast-node :triple/path [_ [_ path]]
   path)
 
-(defmethod f/format-ast-node :triple/vec [_ [_ [s p o]]]
+(defmethod f/format-ast-node :triple.vec/spo [_ [_ [s p o]]]
   (str s " " p " " o " ."))
 
-(defmethod f/format-ast-node :triple/vec-no-po [_ [_ [s]]]
+(defmethod f/format-ast-node :triple.vec/s [_ [_ [s]]]
   (str s " ."))
 
 (defn- format-spo-map [spo pretty?]

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -10,11 +10,9 @@
 (defmethod f/format-ast-node :triple/list [_ [_ list]]
   (str "( " (cstr/join " " list) " )"))
 
-(defmethod f/format-ast-node :triple/bnode-pair [_ [_ [p o]]]
-  (str p " " o))
-
-(defmethod f/format-ast-node :triple/bnodes [{:keys [pretty?]} [_ po-strs]]
-  (let [join-sep (if pretty? " ;\n " " ; ")]
+(defmethod f/format-ast-node :triple/bnodes [{:keys [pretty?]} [_ po-pairs]]
+  (let [join-sep (if pretty? " ;\n  " " ; ")
+        po-strs  (mapv (fn [[p-str o-str]] (str p-str " " o-str)) po-pairs)]
     (str "[ " (cstr/join join-sep po-strs) " ]")))
 
 (defmethod f/format-ast-node :triple.vec/spo [_ [_ [s-str p-str o-str]]]
@@ -23,26 +21,25 @@
 (defmethod f/format-ast-node :triple.vec/s [_ [_ [s-str]]]
   (str s-str " ."))
 
-(defn- format-spo-map [spo pretty?]
+(defmethod f/format-ast-node :triple.nform/spo [{:keys [pretty?]} [_ spo-pairs]]
   (if pretty?
-    (str (->> spo
-              (map (fn [[s po]]
-                     (let [indent (->> (repeat (inc (count s)) " ")
+    (str (->> spo-pairs
+              (map (fn [[s-str po-str]]
+                     (let [indent (->> (repeat (inc (count s-str)) " ")
                                        (cstr/join "")
                                        (str "\n"))]
-                       (str s " " (cstr/replace po #"\n" indent)))))
+                       (str s-str " " (cstr/replace po-str #"\n" indent)))))
               (cstr/join " .\n"))
          " .")
-    (str (->> spo
-              (map (fn [[s po]] (str s " " po)))
+    (str (->> spo-pairs
+              (map (fn [[s-str po-str]] (str s-str " " po-str)))
               (cstr/join " . "))
          " .")))
 
-(defmethod f/format-ast-node :triple.nform/spo [{:keys [pretty?]} [_ spo-strs]]
-  (format-spo-map spo-strs pretty?))
-
-(defmethod f/format-ast-node :triple.nform/s [{:keys [pretty?]} [_ s-str]]
-  (format-spo-map s-str pretty?))
+(defmethod f/format-ast-node :triple.nform/s [{:keys [pretty?]} [_ s-pairs]]
+  (let [join-sep (if pretty? " .\n" " . ")]
+    (str (->> s-pairs (map (fn [[s-str _]] s-str)) (cstr/join join-sep))
+         " .")))
 
 (defmethod f/format-ast-node :triple.nform/po [{:keys [pretty?]} [_ po-strs]]
   (let [join-sep (if pretty? " ;\n" " ; ")]

--- a/src/main/com/yetanalytics/flint/format/triple.cljc
+++ b/src/main/com/yetanalytics/flint/format/triple.cljc
@@ -48,3 +48,16 @@
 
 (defmethod f/format-ast-node :triple/o [_ [_ o]]
   (->> o (cstr/join " , ")))
+
+(defn format-quads [quads pretty?]
+  (-> quads
+      (f/join-clauses pretty?)
+      (f/wrap-in-braces pretty?)))
+
+(defmethod f/format-ast-node :triple/quads
+  [_ [_ [var-or-iri triples-str]]]
+  (str "GRAPH " var-or-iri " " triples-str))
+
+(defmethod f/format-ast-node :triple/quad-triples
+  [{:keys [pretty?]} [_ triples]]
+  (format-quads triples pretty?))

--- a/src/main/com/yetanalytics/flint/format/update.cljc
+++ b/src/main/com/yetanalytics/flint/format/update.cljc
@@ -3,25 +3,8 @@
             [com.yetanalytics.flint.format :as f]
             [com.yetanalytics.flint.format.axiom]
             [com.yetanalytics.flint.format.prologue]
-            [com.yetanalytics.flint.format.triple]
+            [com.yetanalytics.flint.format.triple :as tf]
             [com.yetanalytics.flint.format.where]))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Quads
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(defn- format-quads [quads pretty?]
-  (-> quads
-      (f/join-clauses pretty?)
-      (f/wrap-in-braces pretty?)))
-
-(defmethod f/format-ast-node :triple/quads
-  [_ [_ [var-or-iri triples-str]]]
-  (str "GRAPH " var-or-iri " " triples-str))
-
-(defmethod f/format-ast-node :triple/quad-triples
-  [{:keys [pretty?]} [_ triples]]
-  (format-quads triples pretty?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Graph Management
@@ -128,19 +111,19 @@
   (str "WITH " with))
 
 (defmethod f/format-ast-node :insert-data [{:keys [pretty?]} [_ insert-data]]
-  (str "INSERT DATA " (format-quads insert-data pretty?)))
+  (str "INSERT DATA " (tf/format-quads insert-data pretty?)))
 
 (defmethod f/format-ast-node :delete-data [{:keys [pretty?]} [_ delete-data]]
-  (str "DELETE DATA " (format-quads delete-data pretty?)))
+  (str "DELETE DATA " (tf/format-quads delete-data pretty?)))
 
 (defmethod f/format-ast-node :delete-where [{:keys [pretty?]} [_ delete-where]]
-  (str "DELETE WHERE " (format-quads delete-where pretty?)))
+  (str "DELETE WHERE " (tf/format-quads delete-where pretty?)))
 
 (defmethod f/format-ast-node :delete [{:keys [pretty?]} [_ delete]]
-  (str "DELETE " (format-quads delete pretty?)))
+  (str "DELETE " (tf/format-quads delete pretty?)))
 
 (defmethod f/format-ast-node :insert [{:keys [pretty?]} [_ insert]]
-  (str "INSERT " (format-quads insert pretty?)))
+  (str "INSERT " (tf/format-quads insert pretty?)))
 
 (defmethod f/format-ast-node :update/insert-data [{:keys [pretty?]} [_ id-update]]
   (f/join-clauses id-update pretty?))

--- a/src/main/com/yetanalytics/flint/format/where.cljc
+++ b/src/main/com/yetanalytics/flint/format/where.cljc
@@ -58,5 +58,8 @@
 (defmethod f/format-ast-node :where/special [_ [_ where-form]]
   where-form)
 
+(defmethod f/format-ast-node :where/triple [_ [_ triples]]
+  triples)
+
 (defmethod f/format-ast-node :where [_ [_ where]]
   (str "WHERE " where))

--- a/src/main/com/yetanalytics/flint/spec/query.cljc
+++ b/src/main/com/yetanalytics/flint/spec/query.cljc
@@ -75,13 +75,7 @@
                         ::vs/values]
                :key-comp-fn key-comp))
 
-(def triples-spec
-  (s/coll-of (s/or :triple/vec ts/triple-vec-nopath-spec
-                   :triple/nform ts/normal-form-nopath-spec)
-             :min-count 0
-             :kind vector?))
-
-(s/def ::construct triples-spec)
+(s/def ::construct ts/triple-coll-nopath-spec)
 
 (def construct-query-spec
   (sparql-keys :req-un [::construct ::ws/where]

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -301,25 +301,25 @@
 (def quad-nopath-spec
   (s/and (s/tuple #{:graph}
                   ax/iri-or-var-spec
-                  (s/or :triple/quad-triples triple-coll-nopath-spec))
+                  (s/or :triple.quad/spo triple-coll-nopath-spec))
          (s/conformer (fn [[_ iri triples]] [iri triples]))))
 
 (def quad-novar-spec
   (s/and (s/tuple #{:graph}
                   ax/iri-or-var-spec
-                  (s/or :triple/quad-triples triple-coll-novar-spec))
+                  (s/or :triple.quad/spo triple-coll-novar-spec))
          (s/conformer (fn [[_ iri triples]] [iri triples]))))
 
 (def quad-noblank-spec
   (s/and (s/tuple #{:graph}
                   ax/iri-or-var-spec
-                  (s/or :triple/quad-triples triple-coll-noblank-spec))
+                  (s/or :triple.quad/spo triple-coll-noblank-spec))
          (s/conformer (fn [[_ iri triples]] [iri triples]))))
 
 (def quad-novar-noblank-spec
   (s/and (s/tuple #{:graph}
                   ax/iri-or-var-spec
-                  (s/or :triple/quad-triples triple-coll-novar-noblank-spec))
+                  (s/or :triple.quad/spo triple-coll-novar-noblank-spec))
          (s/conformer (fn [[_ iri triples]] [iri triples]))))
 
 ;; Collection of Quads (for UPDATE)
@@ -329,7 +329,7 @@
                    :triple.vec/s     triple-vec-no-po-nopath-spec
                    :triple.nform/spo normal-form-nopath-spec
                    :triple.nform/s   normal-form-no-po-nopath-spec
-                   :triple/quads     quad-nopath-spec)
+                   :triple.quad/gspo quad-nopath-spec)
              :kind vector?))
 
 (def quad-coll-novar-spec
@@ -337,17 +337,17 @@
                    :triple.vec/s     triple-vec-no-po-novar-spec
                    :triple.nform/spo normal-form-novar-spec
                    :triple.nform/s   normal-form-no-po-novar-spec
-                   :triple/quads     quad-novar-spec)
+                   :triple.quad/gspo quad-novar-spec)
              :kind vector?))
 
 (def quad-coll-noblank-spec
   (s/coll-of (s/or :triple.vec/spo   triple-vec-noblank-spec
                    :triple.nform/spo normal-form-noblank-spec
-                   :triple/quads     quad-noblank-spec)
+                   :triple.quad/gspo quad-noblank-spec)
              :kind vector?))
 
 (def quad-coll-novar-noblank-spec
   (s/coll-of (s/or :triple.vec/spo   triple-vec-novar-noblank-spec
                    :triple.nform/spo normal-form-novar-noblank-spec
-                   :triple/quads     quad-novar-noblank-spec)
+                   :triple.quad/gspo quad-novar-noblank-spec)
              :kind vector?))

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -136,45 +136,20 @@
 ;; Since lists are constructed out of blank nodes, we do not allow list
 ;; syntactic sugar (i.e. `:triple/list`) where blank nodes are banned.
 
-(s/def ::list-entry
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   ::list
-        :triple/bnodes ::bnodes))
-
-(s/def ::list-entry-nopath
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   ::list-nopath
-        :triple/bnodes ::bnodes-nopath))
-
-(s/def ::list-entry-novar
-  (s/or :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   ::list-novar
-        :triple/bnodes ::bnodes-novar))
-
 (s/def ::list
-  (s/coll-of ::list-entry :kind list? :into []))
+  (s/coll-of ::object :kind list? :into []))
 
 (s/def ::list-nopath
-  (s/coll-of ::list-entry-nopath :kind list? :into []))
+  (s/coll-of ::object-nopath :kind list? :into []))
 
 (s/def ::list-novar
-  (s/coll-of ::list-entry-novar :kind list? :into []))
+  (s/coll-of ::object-novar :kind list? :into []))
 
 ;; Blank Node Vectors
 
 (defn- conform-pred-obj-pairs [po-pairs]
-  (mapv (fn [{:keys [pred obj]}] [pred obj]) po-pairs))
+  (mapv (fn [{:keys [pred obj]}] [:triple/bnode-pair [pred obj]])
+        po-pairs))
 
 (s/def ::bnodes
   (s/and vector?

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -127,8 +127,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; NOTE: Subjects can be non-IRIs in SPARQL, but not in RDF
-;; NOTE: RDF collections not supported (yet?)
-
 ;; single-branch `s/or`s are used to conform values
 
 ;; Object
@@ -187,33 +185,43 @@
 ;; Subject Predicate Object
 
 #?(:clj
-   (defmacro make-nform-spec
-     ([subj-spec pred-objs-spec]
-      `(s/or :triple/spo
-             (s/map-of ~subj-spec (s/and ~pred-objs-spec not-empty)
-                       :conform-keys true :into [])))
-     ([subj-spec subj-list-spec pred-objs-spec]
-      `(s/or :triple/spo
-             (s/map-of ~subj-spec (s/and ~pred-objs-spec not-empty)
-                       :conform-keys true :into [])
-             :triple/spo-list
-             (s/map-of ~subj-list-spec ~pred-objs-spec
-                       :conform-keys true :into [])))))
+   (defmacro make-nform-spec [subj-spec pred-objs-spec]
+     `(s/or :triple/spo
+            (s/map-of ~subj-spec (s/and ~pred-objs-spec not-empty)
+                      :conform-keys true :into []))))
 
 (def normal-form-spec
-  (make-nform-spec subj-spec list-spec pred-objs-spec))
+  (make-nform-spec subj-spec pred-objs-spec))
 
 (def normal-form-nopath-spec
-  (make-nform-spec subj-spec list-spec pred-objs-nopath-spec))
+  (make-nform-spec subj-spec pred-objs-nopath-spec))
 
 (def normal-form-novar-spec
-  (make-nform-spec subj-novar-spec list-novar-spec pred-objs-novar-spec))
+  (make-nform-spec subj-novar-spec pred-objs-novar-spec))
 
 (def normal-form-noblank-spec
   (make-nform-spec subj-noblank-spec pred-objs-noblank-spec))
 
 (def normal-form-novar-noblank-spec
   (make-nform-spec subj-novar-noblank-spec pred-objs-novar-noblank-spec))
+
+;; Subject Predicate Object (List)
+
+#?(:clj
+   (defmacro make-nform-list-spec
+     [subj-list-spec pred-objs-spec]
+     `(s/or :triple/spo-list
+            (s/map-of ~subj-list-spec ~pred-objs-spec
+                      :conform-keys true :into []))))
+
+(def normal-form-list-spec
+  (make-nform-list-spec list-spec pred-objs-spec))
+
+(def normal-form-list-nopath-spec
+  (make-nform-list-spec list-spec pred-objs-nopath-spec))
+
+(def normal-form-list-novar-spec
+  (make-nform-list-spec list-spec pred-objs-novar-spec))
 
 ;; Triple Vectors
 
@@ -235,16 +243,19 @@
 ;; Triples
 
 (def triple-spec
-  (s/or :triple/vec   triple-vec-spec
-        :triple/nform normal-form-spec))
+  (s/or :triple/vec        triple-vec-spec
+        :triple/nform      normal-form-spec
+        :triple/nform-list normal-form-list-spec))
 
 (def triple-nopath-spec
-  (s/or :triple/vec   triple-vec-nopath-spec
-        :triple/nform normal-form-nopath-spec))
+  (s/or :triple/vec        triple-vec-nopath-spec
+        :triple/nform      normal-form-nopath-spec
+        :triple/nform-list normal-form-list-nopath-spec))
 
 (def triple-novar-spec
-  (s/or :triple/vec   triple-vec-novar-spec
-        :triple/nform normal-form-novar-spec))
+  (s/or :triple/vec        triple-vec-novar-spec
+        :triple/nform      normal-form-novar-spec
+        :triple/nform-list normal-form-list-nopath-spec))
 
 (def triple-noblank-spec
   (s/or :triple/vec   triple-vec-noblank-spec
@@ -300,15 +311,17 @@
 ;; Collection of Quads (for UPDATE)
 
 (def quad-coll-nopath-spec
-  (s/coll-of (s/or :triple/vec   triple-vec-nopath-spec
-                   :triple/nform normal-form-nopath-spec
-                   :triple/quads quad-nopath-spec)
+  (s/coll-of (s/or :triple/vec        triple-vec-nopath-spec
+                   :triple/nform      normal-form-nopath-spec
+                   :triple/nform-list normal-form-list-nopath-spec
+                   :triple/quads      quad-nopath-spec)
              :kind vector?))
 
 (def quad-coll-novar-spec
-  (s/coll-of (s/or :triple/vec   triple-vec-novar-spec
-                   :triple/nform normal-form-novar-spec
-                   :triple/quads quad-novar-spec)
+  (s/coll-of (s/or :triple/vec        triple-vec-novar-spec
+                   :triple/nform      normal-form-novar-spec
+                   :triple/nform-list normal-form-list-novar-spec
+                   :triple/quads      quad-novar-spec)
              :kind vector?))
 
 (def quad-coll-noblank-spec

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -24,32 +24,110 @@
 ;; - DELETE DATA
 ;; - DELETE
 
-;; Blank Node Vectors
+;; Subjects
 
-(declare pred-spec)
-(declare pred-nopath-spec)
-(declare pred-novar-spec)
+(s/def ::subject
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :triple/list   ::list
+        :triple/bnodes ::bnodes))
 
-(declare obj-spec)
-(declare obj-novar-spec)
+(s/def ::subject-coll
+  (s/or :triple/list   ::list
+        :triple/bnodes ::bnodes))
 
-(defn- conform-pred-obj-pairs [po-pairs]
-  (mapv (fn [{:keys [pred obj]}] [pred obj]) po-pairs))
+(s/def ::subject-nopath
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :triple/list   ::list-nopath
+        :triple/bnodes ::bnodes-nopath))
 
-(def bnode-vec-spec
-  (s/and vector?
-         (s/* (s/cat :pred pred-spec :obj obj-spec))
-         (s/conformer conform-pred-obj-pairs)))
+(s/def ::subject-coll-nopath
+  (s/or :triple/list   ::list-nopath
+        :triple/bnodes ::bnodes-nopath))
 
-(def bnode-vec-nopath-spec
-  (s/and vector?
-         (s/* (s/cat :pred pred-nopath-spec :obj obj-spec))
-         (s/conformer conform-pred-obj-pairs)))
+(s/def ::subject-novar
+  (s/or :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :triple/list   ::list-novar
+        :triple/bnodes ::bnodes-novar))
 
-(def bnode-vec-novar-spec
-  (s/and vector?
-         (s/* (s/cat :pred pred-novar-spec :obj obj-novar-spec))
-         (s/conformer conform-pred-obj-pairs)))
+(s/def ::subject-coll-novar
+  (s/or :triple/list   ::list-novar
+        :triple/bnodes ::bnodes-novar))
+
+(s/def ::subject-noblank
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec))
+
+(s/def ::subject-novar-noblank
+  (s/or :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec))
+
+;; Predicates
+
+(s/def ::predicate
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/rdf-type   ax/rdf-type-spec
+        :triple/path   ::ps/path))
+
+(s/def ::predicate-nopath
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/rdf-type   ax/rdf-type-spec))
+
+(s/def ::predicate-novar
+  (s/or :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/rdf-type   ax/rdf-type-spec))
+
+;; Objects (includes Lists)
+
+(s/def ::object
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   ::list
+        :triple/bnodes ::bnodes))
+
+(s/def ::object-nopath
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   ::list-nopath
+        :triple/bnodes ::bnodes-nopath))
+
+(s/def ::object-novar
+  (s/or :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   ::list-nopath
+        :triple/bnodes ::bnodes-nopath))
+
+(s/def ::object-noblank
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/literal    ax/literal-spec))
+
+(s/def ::object-novar-noblank
+  (s/or :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/literal    ax/literal-spec))
 
 ;; Lists
 
@@ -58,148 +136,60 @@
 ;; Since lists are constructed out of blank nodes, we do not allow list
 ;; syntactic sugar (i.e. `:triple/list`) where blank nodes are banned.
 
-(declare list-spec)
-(declare list-novar-spec)
-
-(def list-entry-spec
+(s/def ::list-entry
   (s/or :ax/var        ax/variable-spec
         :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
         :ax/literal    ax/literal-spec
-        :triple/list   list-spec
-        :triple/bnodes bnode-vec-spec))
+        :triple/list   ::list
+        :triple/bnodes ::bnodes))
 
-(def list-entry-nopath-spec
+(s/def ::list-entry-nopath
   (s/or :ax/var        ax/variable-spec
         :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
         :ax/literal    ax/literal-spec
-        :triple/list   list-spec
-        :triple/bnodes bnode-vec-nopath-spec))
+        :triple/list   ::list-nopath
+        :triple/bnodes ::bnodes-nopath))
 
-(def list-entry-novar-spec
+(s/def ::list-entry-novar
   (s/or :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
         :ax/literal    ax/literal-spec
-        :triple/list   list-novar-spec
-        :triple/bnodes bnode-vec-novar-spec))
+        :triple/list   ::list-novar
+        :triple/bnodes ::bnodes-novar))
 
-(def list-spec
-  (s/coll-of list-entry-spec :kind list? :into []))
+(s/def ::list
+  (s/coll-of ::list-entry :kind list? :into []))
 
-(def list-nopath-spec
-  (s/coll-of list-entry-nopath-spec :kind list? :into []))
+(s/def ::list-nopath
+  (s/coll-of ::list-entry-nopath :kind list? :into []))
 
-(def list-novar-spec
-  (s/coll-of list-entry-novar-spec :kind list? :into []))
+(s/def ::list-novar
+  (s/coll-of ::list-entry-novar :kind list? :into []))
 
-;; Subjects
+;; Blank Node Vectors
 
-(def subj-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :triple/list   list-spec
-        :triple/bnodes bnode-vec-spec))
+(defn- conform-pred-obj-pairs [po-pairs]
+  (mapv (fn [{:keys [pred obj]}] [pred obj]) po-pairs))
 
-(def subj-coll-spec
-  (s/or :triple/list   list-spec
-        :triple/bnodes bnode-vec-spec))
+(s/def ::bnodes
+  (s/and vector?
+         (s/* (s/cat :pred ::predicate :obj ::object))
+         (s/conformer conform-pred-obj-pairs)))
 
-(def subj-nopath-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :triple/list   list-nopath-spec
-        :triple/bnodes bnode-vec-nopath-spec))
+(s/def ::bnodes-nopath
+  (s/and vector?
+         (s/* (s/cat :pred ::predicate-nopath :obj ::object))
+         (s/conformer conform-pred-obj-pairs)))
 
-(def subj-coll-nopath-spec
-  (s/or :triple/list   list-nopath-spec
-        :triple/bnodes bnode-vec-nopath-spec))
-
-(def subj-novar-spec
-  (s/or :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :triple/list   list-spec
-        :triple/bnodes bnode-vec-novar-spec))
-
-(def subj-coll-novar-spec
-  (s/or :triple/list   list-novar-spec
-        :triple/bnodes bnode-vec-novar-spec))
-
-(def subj-noblank-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec))
-
-(def subj-novar-noblank-spec
-  (s/or :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec))
-
-;; Predicates
-
-(def pred-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/rdf-type   ax/rdf-type-spec
-        :triple/path   ::ps/path))
-
-(def pred-nopath-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/rdf-type   ax/rdf-type-spec))
-
-(def pred-novar-spec
-  (s/or :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/rdf-type   ax/rdf-type-spec))
-
-;; Objects (includes Lists)
-
-(def obj-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   list-spec
-        :triple/bnodes bnode-vec-spec))
-
-(def obj-nopath-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   list-nopath-spec
-        :triple/bnodes bnode-vec-nopath-spec))
-
-(def obj-novar-spec
-  (s/or :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   list-novar-spec
-        :triple/bnodes bnode-vec-novar-spec))
-
-(def obj-noblank-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/literal    ax/literal-spec))
-
-(def obj-novar-noblank-spec
-  (s/or :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/literal    ax/literal-spec))
+(s/def ::bnodes-novar
+  (s/and vector?
+         (s/* (s/cat :pred ::predicate-novar :obj ::object-novar))
+         (s/conformer conform-pred-obj-pairs)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Combo Specs
@@ -216,19 +206,19 @@
       `(s/coll-of ~obj-spec :min-count 1 :kind set? :into []))))
 
 (def obj-set-spec
-  (make-obj-spec obj-spec))
+  (make-obj-spec ::object))
 
 (def obj-set-nopath-spec
-  (make-obj-spec obj-nopath-spec))
+  (make-obj-spec ::object-nopath))
 
 (def obj-set-novar-spec
-  (make-obj-spec obj-novar-spec))
+  (make-obj-spec ::object-novar))
 
 (def obj-set-noblank-spec
-  (make-obj-spec obj-noblank-spec))
+  (make-obj-spec ::object-noblank))
 
 (def obj-set-novar-noblank-spec
-  (make-obj-spec obj-novar-noblank-spec))
+  (make-obj-spec ::object-novar-noblank))
 
 ;; Predicate Object
 
@@ -240,19 +230,19 @@
                 :min-count 1)))
 
 (def pred-objs-spec
-  (make-pred-objs-spec pred-spec obj-set-spec))
+  (make-pred-objs-spec ::predicate obj-set-spec))
 
 (def pred-objs-nopath-spec
-  (make-pred-objs-spec pred-nopath-spec obj-set-nopath-spec))
+  (make-pred-objs-spec ::predicate-nopath obj-set-nopath-spec))
 
 (def pred-objs-novar-spec
-  (make-pred-objs-spec pred-novar-spec obj-set-novar-spec))
+  (make-pred-objs-spec ::predicate-novar obj-set-novar-spec))
 
 (def pred-objs-noblank-spec
-  (make-pred-objs-spec pred-nopath-spec obj-set-noblank-spec))
+  (make-pred-objs-spec ::predicate-nopath obj-set-noblank-spec))
 
 (def pred-objs-novar-noblank-spec
-  (make-pred-objs-spec pred-novar-spec obj-set-novar-noblank-spec))
+  (make-pred-objs-spec ::predicate-novar obj-set-novar-noblank-spec))
 
 ;; Subject Predicate Object
 
@@ -262,19 +252,19 @@
                 :conform-keys true :into [])))
 
 (def normal-form-spec
-  (make-nform-spec subj-spec pred-objs-spec))
+  (make-nform-spec ::subject pred-objs-spec))
 
 (def normal-form-nopath-spec
-  (make-nform-spec subj-nopath-spec pred-objs-nopath-spec))
+  (make-nform-spec ::subject-nopath pred-objs-nopath-spec))
 
 (def normal-form-novar-spec
-  (make-nform-spec subj-novar-spec pred-objs-novar-spec))
+  (make-nform-spec ::subject-novar pred-objs-novar-spec))
 
 (def normal-form-noblank-spec
-  (make-nform-spec subj-noblank-spec pred-objs-noblank-spec))
+  (make-nform-spec ::subject-noblank pred-objs-noblank-spec))
 
 (def normal-form-novar-noblank-spec
-  (make-nform-spec subj-novar-noblank-spec pred-objs-novar-noblank-spec))
+  (make-nform-spec ::subject-novar-noblank pred-objs-novar-noblank-spec))
 
 ;; Subject Predicate Object (List)
 
@@ -287,41 +277,41 @@
                 :conform-keys true :into [])))
 
 (def normal-form-no-po-spec
-  (make-nform-no-po-spec subj-coll-spec))
+  (make-nform-no-po-spec ::subject-coll))
 
 (def normal-form-no-po-nopath-spec
-  (make-nform-no-po-spec subj-coll-nopath-spec))
+  (make-nform-no-po-spec ::subject-coll-nopath))
 
 (def normal-form-no-po-novar-spec
-  (make-nform-no-po-spec subj-coll-novar-spec))
+  (make-nform-no-po-spec ::subject-coll-novar))
 
 ;; Triple Vectors
 
 (def triple-vec-spec
-  (s/tuple subj-spec pred-spec obj-spec))
+  (s/tuple ::subject ::predicate ::object))
 
 (def triple-vec-nopath-spec
-  (s/tuple subj-spec pred-nopath-spec obj-spec))
+  (s/tuple ::subject ::predicate-nopath ::object))
 
 (def triple-vec-novar-spec
-  (s/tuple subj-novar-spec pred-novar-spec obj-novar-spec))
+  (s/tuple ::subject-novar ::predicate-novar ::object-novar))
 
 (def triple-vec-noblank-spec
-  (s/tuple subj-noblank-spec pred-nopath-spec obj-noblank-spec))
+  (s/tuple ::subject-noblank ::predicate-nopath ::object-noblank))
 
 (def triple-vec-novar-noblank-spec
-  (s/tuple subj-novar-noblank-spec pred-novar-spec obj-novar-noblank-spec))
+  (s/tuple ::subject-novar-noblank ::predicate-novar ::object-novar-noblank))
 
 ;; Triple Vectors (List, no predicates + objects)
 
 (def triple-vec-no-po-spec
-  (s/tuple subj-coll-spec))
+  (s/tuple ::subject-coll))
 
 (def triple-vec-no-po-nopath-spec
-  (s/tuple subj-coll-spec))
+  (s/tuple ::subject-coll))
 
 (def triple-vec-no-po-novar-spec
-  (s/tuple subj-coll-novar-spec))
+  (s/tuple ::subject-coll-novar))
 
 ;; Triples
 

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -131,8 +131,6 @@
 
 ;; Lists
 
-;; List entries have the same spec as objects + `:triple/list`
-
 ;; Since lists are constructed out of blank nodes, we do not allow list
 ;; syntactic sugar (i.e. `:triple/list`) where blank nodes are banned.
 
@@ -146,6 +144,9 @@
   (s/coll-of ::object-novar :kind list? :into []))
 
 ;; Blank Node Vectors
+
+;; For obvious reasons, we don't allow bnode vectors to exist where blank
+;; nodes are banned.
 
 (defn- conform-pred-obj-pairs [po-pairs]
   (mapv (fn [{:keys [pred obj]}] [pred obj]) po-pairs))

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -223,10 +223,6 @@
 (def normal-form-no-po-novar-spec
   (make-nform-no-po-spec subj-list-novar-spec))
 
-(comment
-  (s/conform normal-form-no-po-spec
-             {'(?x ?y ?z) {}}))
-
 ;; Triple Vectors
 
 (def triple-vec-spec
@@ -258,29 +254,29 @@
 ;; Triples
 
 (def triple-spec
-  (s/or :triple/vec       triple-vec-spec
-        :triple/vec-no-po triple-vec-no-po-spec
+  (s/or :triple.vec/spo   triple-vec-spec
+        :triple.vec/s     triple-vec-no-po-spec
         :triple.nform/spo normal-form-spec
         :triple.nform/s   normal-form-no-po-spec))
 
 (def triple-nopath-spec
-  (s/or :triple/vec       triple-vec-nopath-spec
-        :triple/vec-no-po triple-vec-no-po-nopath-spec
+  (s/or :triple.vec/spo   triple-vec-nopath-spec
+        :triple.vec/s     triple-vec-no-po-nopath-spec
         :triple.nform/spo normal-form-nopath-spec
         :triple.nform/s   normal-form-no-po-nopath-spec))
 
 (def triple-novar-spec
-  (s/or :triple/vec       triple-vec-novar-spec
-        :triple/vec-no-po triple-vec-no-po-novar-spec
+  (s/or :triple.vec/spo   triple-vec-novar-spec
+        :triple.vec/s     triple-vec-no-po-novar-spec
         :triple.nform/spo normal-form-novar-spec
         :triple.nform/s   normal-form-no-po-nopath-spec))
 
 (def triple-noblank-spec
-  (s/or :triple/vec       triple-vec-noblank-spec
+  (s/or :triple.vec/spo   triple-vec-noblank-spec
         :triple.nform/spo normal-form-noblank-spec))
 
 (def triple-novar-noblank-spec
-  (s/or :triple/vec       triple-vec-novar-noblank-spec
+  (s/or :triple.vec/spo   triple-vec-novar-noblank-spec
         :triple.nform/spo normal-form-novar-noblank-spec))
 
 ;; Collection of Triples
@@ -329,29 +325,29 @@
 ;; Collection of Quads (for UPDATE)
 
 (def quad-coll-nopath-spec
-  (s/coll-of (s/or :triple/vec       triple-vec-nopath-spec
-                   :triple/vec-no-po triple-vec-no-po-nopath-spec
+  (s/coll-of (s/or :triple.vec/spo   triple-vec-nopath-spec
+                   :triple.vec/s     triple-vec-no-po-nopath-spec
                    :triple.nform/spo normal-form-nopath-spec
                    :triple.nform/s   normal-form-no-po-nopath-spec
                    :triple/quads     quad-nopath-spec)
              :kind vector?))
 
 (def quad-coll-novar-spec
-  (s/coll-of (s/or :triple/vec        triple-vec-novar-spec
-                   :triple/vec-no-po  triple-vec-no-po-novar-spec
-                   :triple.nform/spo      normal-form-novar-spec
-                   :triple.nform/s normal-form-no-po-novar-spec
-                   :triple/quads      quad-novar-spec)
+  (s/coll-of (s/or :triple.vec/spo   triple-vec-novar-spec
+                   :triple.vec/s     triple-vec-no-po-novar-spec
+                   :triple.nform/spo normal-form-novar-spec
+                   :triple.nform/s   normal-form-no-po-novar-spec
+                   :triple/quads     quad-novar-spec)
              :kind vector?))
 
 (def quad-coll-noblank-spec
-  (s/coll-of (s/or :triple/vec   triple-vec-noblank-spec
+  (s/coll-of (s/or :triple.vec/spo   triple-vec-noblank-spec
                    :triple.nform/spo normal-form-noblank-spec
-                   :triple/quads quad-noblank-spec)
+                   :triple/quads     quad-noblank-spec)
              :kind vector?))
 
 (def quad-coll-novar-noblank-spec
-  (s/coll-of (s/or :triple/vec   triple-vec-novar-noblank-spec
+  (s/coll-of (s/or :triple.vec/spo   triple-vec-novar-noblank-spec
                    :triple.nform/spo normal-form-novar-noblank-spec
-                   :triple/quads quad-novar-noblank-spec)
+                   :triple/quads     quad-novar-noblank-spec)
              :kind vector?))

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -231,3 +231,94 @@
 
 (def triple-vec-novar-noblank-spec
   (s/tuple subj-novar-noblank-spec pred-novar-spec obj-novar-noblank-spec))
+
+;; Triples
+
+(def triple-spec
+  (s/or :triple/vec   triple-vec-spec
+        :triple/nform normal-form-spec))
+
+(def triple-nopath-spec
+  (s/or :triple/vec   triple-vec-nopath-spec
+        :triple/nform normal-form-nopath-spec))
+
+(def triple-novar-spec
+  (s/or :triple/vec   triple-vec-novar-spec
+        :triple/nform normal-form-novar-spec))
+
+(def triple-noblank-spec
+  (s/or :triple/vec   triple-vec-noblank-spec
+        :triple/nform normal-form-noblank-spec))
+
+(def triple-novar-noblank-spec
+  (s/or :triple/vec   triple-vec-novar-noblank-spec
+        :triple/nform normal-form-novar-noblank-spec))
+
+;; Collection of Triples
+
+(def triple-coll-spec
+  (s/coll-of triple-spec :kind vector?))
+
+(def triple-coll-nopath-spec
+  (s/coll-of triple-nopath-spec :kind vector?))
+
+(def triple-coll-novar-spec
+  (s/coll-of triple-novar-spec :kind vector?))
+
+(def triple-coll-noblank-spec
+  (s/coll-of triple-noblank-spec :kind vector?))
+
+(def triple-coll-novar-noblank-spec
+  (s/coll-of triple-novar-noblank-spec :kind vector?))
+
+;; Quads (for UPDATE)
+
+(def quad-nopath-spec
+  (s/and (s/tuple #{:graph}
+                  ax/iri-or-var-spec
+                  (s/or :triple/quad-triples triple-coll-nopath-spec))
+         (s/conformer (fn [[_ iri triples]] [iri triples]))))
+
+(def quad-novar-spec
+  (s/and (s/tuple #{:graph}
+                  ax/iri-or-var-spec
+                  (s/or :triple/quad-triples triple-coll-novar-spec))
+         (s/conformer (fn [[_ iri triples]] [iri triples]))))
+
+(def quad-noblank-spec
+  (s/and (s/tuple #{:graph}
+                  ax/iri-or-var-spec
+                  (s/or :triple/quad-triples triple-coll-noblank-spec))
+         (s/conformer (fn [[_ iri triples]] [iri triples]))))
+
+(def quad-novar-noblank-spec
+  (s/and (s/tuple #{:graph}
+                  ax/iri-or-var-spec
+                  (s/or :triple/quad-triples triple-coll-novar-noblank-spec))
+         (s/conformer (fn [[_ iri triples]] [iri triples]))))
+
+;; Collection of Quads (for UPDATE)
+
+(def quad-coll-nopath-spec
+  (s/coll-of (s/or :triple/vec   triple-vec-nopath-spec
+                   :triple/nform normal-form-nopath-spec
+                   :triple/quads quad-nopath-spec)
+             :kind vector?))
+
+(def quad-coll-novar-spec
+  (s/coll-of (s/or :triple/vec   triple-vec-novar-spec
+                   :triple/nform normal-form-novar-spec
+                   :triple/quads quad-novar-spec)
+             :kind vector?))
+
+(def quad-coll-noblank-spec
+  (s/coll-of (s/or :triple/vec   triple-vec-noblank-spec
+                   :triple/nform normal-form-noblank-spec
+                   :triple/quads quad-noblank-spec)
+             :kind vector?))
+
+(def quad-coll-novar-noblank-spec
+  (s/coll-of (s/or :triple/vec   triple-vec-novar-noblank-spec
+                   :triple/nform normal-form-novar-noblank-spec
+                   :triple/quads quad-novar-noblank-spec)
+             :kind vector?))

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -54,6 +54,33 @@
 (def list-novar-spec
   (s/coll-of list-entry-novar-spec :kind list?))
 
+;; Blank Node Vectors
+
+(declare pred-spec)
+(declare pred-nopath-spec)
+(declare pred-novar-spec)
+
+(declare obj-spec)
+(declare obj-novar-spec)
+
+(defn- conform-pred-obj-pairs [po-pairs]
+  (mapv (fn [{:keys [pred obj]}] [pred obj]) po-pairs))
+
+(def bnode-vec-spec
+  (s/and vector?
+         (s/* (s/cat :pred pred-spec :obj obj-spec))
+         (s/conformer conform-pred-obj-pairs)))
+
+(def bnode-vec-nopath-spec
+  (s/and vector?
+         (s/* (s/cat :pred pred-nopath-spec :obj obj-spec))
+         (s/conformer conform-pred-obj-pairs)))
+
+(def bnode-vec-novar-spec
+  (s/and vector?
+         (s/* (s/cat :pred pred-novar-spec :obj obj-novar-spec))
+         (s/conformer conform-pred-obj-pairs)))
+
 ;; Subjects
 
 (def subj-spec
@@ -61,19 +88,35 @@
         :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
-        :triple/list   list-spec))
+        :triple/list   list-spec
+        :triple/bnodes bnode-vec-spec))
 
-(def subj-list-spec
-  (s/or :triple/list list-spec))
+(def subj-coll-spec
+  (s/or :triple/list   list-spec
+        :triple/bnodes bnode-vec-spec))
+
+(def subj-nopath-spec
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :triple/list   list-spec
+        :triple/bnodes bnode-vec-nopath-spec))
+
+(def subj-coll-nopath-spec
+  (s/or :triple/list   list-spec
+        :triple/bnodes bnode-vec-nopath-spec))
 
 (def subj-novar-spec
   (s/or :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
-        :triple/list   list-spec))
+        :triple/list   list-spec
+        :triple/bnodes bnode-vec-novar-spec))
 
-(def subj-list-novar-spec
-  (s/or :triple/list list-novar-spec))
+(def subj-coll-novar-spec
+  (s/or :triple/list   list-novar-spec
+        :triple/bnodes bnode-vec-novar-spec))
 
 (def subj-noblank-spec
   (s/or :ax/var        ax/variable-spec
@@ -112,14 +155,25 @@
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
         :ax/literal    ax/literal-spec
-        :triple/list   list-spec))
+        :triple/list   list-spec
+        :triple/bnodes bnode-vec-spec))
+
+(def obj-nopath-spec
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   list-spec
+        :triple/bnodes bnode-vec-nopath-spec))
 
 (def obj-novar-spec
   (s/or :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
         :ax/literal    ax/literal-spec
-        :triple/list   list-novar-spec))
+        :triple/list   list-novar-spec
+        :triple/bnodes bnode-vec-novar-spec))
 
 (def obj-noblank-spec
   (s/or :ax/var        ax/variable-spec
@@ -149,6 +203,9 @@
 (def obj-set-spec
   (make-obj-spec obj-spec))
 
+(def obj-set-nopath-spec
+  (make-obj-spec obj-nopath-spec))
+
 (def obj-set-novar-spec
   (make-obj-spec obj-novar-spec))
 
@@ -171,7 +228,7 @@
   (make-pred-objs-spec pred-spec obj-set-spec))
 
 (def pred-objs-nopath-spec
-  (make-pred-objs-spec pred-nopath-spec obj-set-spec))
+  (make-pred-objs-spec pred-nopath-spec obj-set-nopath-spec))
 
 (def pred-objs-novar-spec
   (make-pred-objs-spec pred-novar-spec obj-set-novar-spec))
@@ -193,7 +250,7 @@
   (make-nform-spec subj-spec pred-objs-spec))
 
 (def normal-form-nopath-spec
-  (make-nform-spec subj-spec pred-objs-nopath-spec))
+  (make-nform-spec subj-nopath-spec pred-objs-nopath-spec))
 
 (def normal-form-novar-spec
   (make-nform-spec subj-novar-spec pred-objs-novar-spec))
@@ -215,13 +272,13 @@
                 :conform-keys true :into [])))
 
 (def normal-form-no-po-spec
-  (make-nform-no-po-spec subj-list-spec))
+  (make-nform-no-po-spec subj-coll-spec))
 
 (def normal-form-no-po-nopath-spec
-  (make-nform-no-po-spec subj-list-spec))
+  (make-nform-no-po-spec subj-coll-nopath-spec))
 
 (def normal-form-no-po-novar-spec
-  (make-nform-no-po-spec subj-list-novar-spec))
+  (make-nform-no-po-spec subj-coll-novar-spec))
 
 ;; Triple Vectors
 
@@ -243,13 +300,13 @@
 ;; Triple Vectors (List, no predicates + objects)
 
 (def triple-vec-no-po-spec
-  (s/tuple subj-list-spec))
+  (s/tuple subj-coll-spec))
 
 (def triple-vec-no-po-nopath-spec
-  (s/tuple subj-list-spec))
+  (s/tuple subj-coll-spec))
 
 (def triple-vec-no-po-novar-spec
-  (s/tuple subj-list-novar-spec))
+  (s/tuple subj-coll-novar-spec))
 
 ;; Triples
 

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -23,6 +23,37 @@
 ;; - DELETE DATA
 ;; - DELETE
 
+;; Lists
+
+;; List entries have the same spec as objects + `:triple/list`
+
+;; Since lists are constructed out of blank nodes, we do not allow list
+;; syntactic sugar (i.e. `:triple/list`) where blank nodes are banned.
+
+(declare list-spec)
+(declare list-novar-spec)
+
+(def list-entry-spec
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   list-spec))
+
+(def list-entry-novar-spec
+  (s/or :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   list-novar-spec))
+
+(def list-spec
+  (s/coll-of list-entry-spec :kind list?))
+
+(def list-novar-spec
+  (s/coll-of list-entry-novar-spec :kind list?))
+
 ;; Subjects
 
 (def subj-spec
@@ -31,10 +62,16 @@
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec))
 
+(def subj-list-spec
+  (s/or :triple/list   list-spec))
+
 (def subj-novar-spec
   (s/or :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec))
+
+(def subj-list-novar-spec
+  (s/or :triple/list   list-novar-spec))
 
 (def subj-noblank-spec
   (s/or :ax/var        ax/variable-spec
@@ -72,13 +109,15 @@
         :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec))
+        :ax/literal    ax/literal-spec
+        :triple/list   list-spec))
 
 (def obj-novar-spec
   (s/or :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec))
+        :ax/literal    ax/literal-spec
+        :triple/list   list-novar-spec))
 
 (def obj-noblank-spec
   (s/or :ax/var        ax/variable-spec
@@ -90,37 +129,6 @@
   (s/or :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/literal    ax/literal-spec))
-
-;; Lists
-
-;; List entries have the same spec as objects + `:triple/list`
-
-;; Since lists are constructed out of blank nodes, we do not allow list
-;; syntactic sugar (i.e. `:triple/list`) where blank nodes are banned.
-
-(declare list-spec)
-(declare list-novar-spec)
-
-(def list-entry-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   list-spec))
-
-(def list-entry-novar-spec
-  (s/or :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   list-novar-spec))
-
-(def list-spec
-  (s/coll-of list-entry-spec :kind list?))
-
-(def list-novar-spec
-  (s/coll-of list-entry-novar-spec :kind list?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Combo Specs
@@ -134,24 +142,16 @@
 #?(:clj
    (defmacro make-obj-spec
      ([obj-spec]
-      `(s/or :triple/o
-             (s/coll-of (s/or :triple/object ~obj-spec)
-                        :min-count 1
-                        :kind set?
-                        :into [])))
-     ([obj-spec obj-list-spec]
-      `(s/or :triple/o
-             (s/coll-of (s/or :triple/object ~obj-spec
-                              :triple/list ~obj-list-spec)
-                        :min-count 1
-                        :kind set?
-                        :into [])))))
+      `(s/or :triple/o (s/coll-of ~obj-spec
+                                  :min-count 1
+                                  :kind set?
+                                  :into [])))))
 
 (def obj-set-spec
-  (make-obj-spec obj-spec list-spec))
+  (make-obj-spec obj-spec))
 
 (def obj-set-novar-spec
-  (make-obj-spec obj-novar-spec list-novar-spec))
+  (make-obj-spec obj-novar-spec))
 
 (def obj-set-noblank-spec
   (make-obj-spec obj-noblank-spec))
@@ -208,20 +208,19 @@
 ;; Subject Predicate Object (List)
 
 #?(:clj
-   (defmacro make-nform-list-spec
-     [subj-list-spec pred-objs-spec]
+   (defmacro make-nform-list-spec [subj-list-spec pred-objs-spec]
      `(s/or :triple/spo-list
             (s/map-of ~subj-list-spec ~pred-objs-spec
                       :conform-keys true :into []))))
 
 (def normal-form-list-spec
-  (make-nform-list-spec list-spec pred-objs-spec))
+  (make-nform-list-spec subj-list-spec pred-objs-spec))
 
 (def normal-form-list-nopath-spec
-  (make-nform-list-spec list-spec pred-objs-nopath-spec))
+  (make-nform-list-spec subj-list-spec pred-objs-nopath-spec))
 
 (def normal-form-list-novar-spec
-  (make-nform-list-spec list-spec pred-objs-novar-spec))
+  (make-nform-list-spec subj-list-novar-spec pred-objs-novar-spec))
 
 ;; Triple Vectors
 

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -148,8 +148,7 @@
 ;; Blank Node Vectors
 
 (defn- conform-pred-obj-pairs [po-pairs]
-  (mapv (fn [{:keys [pred obj]}] [:triple/bnode-pair [pred obj]])
-        po-pairs))
+  (mapv (fn [{:keys [pred obj]}] [pred obj]) po-pairs))
 
 (s/def ::bnodes
   (s/and vector?

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -14,14 +14,14 @@
 ;; Just paths banned in
 ;; - CONSTRUCT
 
+;; Variables (and paths) banned in
+;; - DELETE DATA
+;; - INSERT DATA
+
 ;; Blank nodes (and paths) banned in
 ;; - DELETE WHERE
 ;; - DELETE DATA
 ;; - DELETE
-
-;; Variables (and paths) banned in
-;; - DELETE DATA
-;; - INSERT DATA
 
 ;; Subjects
 
@@ -90,6 +90,37 @@
   (s/or :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/literal    ax/literal-spec))
+
+;; Lists
+
+;; List entries have the same spec as objects + `:triple/list`
+
+;; Since lists are constructed out of blank nodes, we do not allow list
+;; syntactic sugar (i.e. `:triple/list`) where blank nodes are banned.
+
+(declare list-spec)
+(declare list-novar-spec)
+
+(def list-entry-spec
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   list-spec))
+
+(def list-entry-novar-spec
+  (s/or :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   list-novar-spec))
+
+(def list-spec
+  (s/coll-of list-entry-spec :kind list?))
+
+(def list-novar-spec
+  (s/coll-of list-entry-novar-spec :kind list?))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Combo Specs

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -5,8 +5,7 @@
   #?(:cljs (:require-macros [com.yetanalytics.flint.spec.triple
                              :refer [make-obj-spec
                                      make-pred-objs-spec
-                                     make-nform-spec
-                                     make-nform-no-po-spec]])))
+                                     make-nform-spec]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Subj/Pred/Obj Specs
@@ -228,13 +227,14 @@
 (def empty-map-spec
   (s/map-of any? any? :count 0 :conform-keys true :into []))
 
-#?(:clj
-   (defn- valid-conformed-spo? [spo-pairs]
-     (every?
-      (fn [[s po]]
-        (or (#{:triple/list :triple/bnodes} (first s))
-            (#{:triple.nform/po} (first po))))
-      spo-pairs)))
+;; cljs-specific ignore is needed since this fn is called in a macro.
+#_{:clj-kondo/ignore #?(:clj [] :cljs [:unused-private-var])}
+(defn- valid-conformed-spo? [spo-pairs]
+  (every?
+   (fn [[s po]]
+     (or (#{:triple/list :triple/bnodes} (first s))
+         (#{:triple.nform/po} (first po))))
+   spo-pairs))
 
 #?(:clj
    (defmacro make-nform-spec [subj-spec pred-objs-spec]

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -5,7 +5,8 @@
   #?(:cljs (:require-macros [com.yetanalytics.flint.spec.triple
                              :refer [make-obj-spec
                                      make-pred-objs-spec
-                                     make-nform-spec]])))
+                                     make-nform-spec
+                                     make-nform-no-po-spec]])))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Subj/Pred/Obj Specs

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -144,10 +144,7 @@
 #?(:clj
    (defmacro make-obj-spec
      ([obj-spec]
-      `(s/or :triple/o (s/coll-of ~obj-spec
-                                  :min-count 1
-                                  :kind set?
-                                  :into [])))))
+      `(s/coll-of ~obj-spec :min-count 1 :kind set? :into []))))
 
 (def obj-set-spec
   (make-obj-spec obj-spec))
@@ -166,9 +163,9 @@
 #?(:clj
    (defmacro make-pred-objs-spec
      [pred-spec objs-spec]
-     `(s/or :triple/po (s/map-of ~pred-spec ~objs-spec
-                                 :into []
-                                 :min-count 1))))
+     `(s/map-of ~pred-spec (s/or :triple.nform/o ~objs-spec)
+                :into []
+                :min-count 1)))
 
 (def pred-objs-spec
   (make-pred-objs-spec pred-spec obj-set-spec))
@@ -189,9 +186,8 @@
 
 #?(:clj
    (defmacro make-nform-spec [subj-spec pred-objs-spec]
-     `(s/or :triple/spo
-            (s/map-of ~subj-spec ~pred-objs-spec
-                      :conform-keys true :into []))))
+     `(s/map-of ~subj-spec (s/or :triple.nform/po ~pred-objs-spec)
+                :conform-keys true :into [])))
 
 (def normal-form-spec
   (make-nform-spec subj-spec pred-objs-spec))
@@ -215,9 +211,8 @@
 
 #?(:clj
    (defmacro make-nform-no-po-spec [subj-list-spec]
-     `(s/or :triple/spo
-            (s/map-of ~subj-list-spec empty-map-spec
-                      :conform-keys true :into []))))
+     `(s/map-of ~subj-list-spec empty-map-spec
+                :conform-keys true :into [])))
 
 (def normal-form-no-po-spec
   (make-nform-no-po-spec subj-list-spec))
@@ -263,30 +258,30 @@
 ;; Triples
 
 (def triple-spec
-  (s/or :triple/vec         triple-vec-spec
-        :triple/vec-no-po   triple-vec-no-po-spec
-        :triple/nform       normal-form-spec
-        :triple/nform-no-po normal-form-no-po-spec))
+  (s/or :triple/vec       triple-vec-spec
+        :triple/vec-no-po triple-vec-no-po-spec
+        :triple.nform/spo normal-form-spec
+        :triple.nform/s   normal-form-no-po-spec))
 
 (def triple-nopath-spec
-  (s/or :triple/vec         triple-vec-nopath-spec
-        :triple/vec-no-po   triple-vec-no-po-nopath-spec
-        :triple/nform       normal-form-nopath-spec
-        :triple/nform-no-po normal-form-no-po-nopath-spec))
+  (s/or :triple/vec       triple-vec-nopath-spec
+        :triple/vec-no-po triple-vec-no-po-nopath-spec
+        :triple.nform/spo normal-form-nopath-spec
+        :triple.nform/s   normal-form-no-po-nopath-spec))
 
 (def triple-novar-spec
-  (s/or :triple/vec         triple-vec-novar-spec
-        :triple/vec-no-po   triple-vec-no-po-novar-spec
-        :triple/nform       normal-form-novar-spec
-        :triple/nform-no-po normal-form-no-po-nopath-spec))
+  (s/or :triple/vec       triple-vec-novar-spec
+        :triple/vec-no-po triple-vec-no-po-novar-spec
+        :triple.nform/spo normal-form-novar-spec
+        :triple.nform/s   normal-form-no-po-nopath-spec))
 
 (def triple-noblank-spec
-  (s/or :triple/vec   triple-vec-noblank-spec
-        :triple/nform normal-form-noblank-spec))
+  (s/or :triple/vec       triple-vec-noblank-spec
+        :triple.nform/spo normal-form-noblank-spec))
 
 (def triple-novar-noblank-spec
-  (s/or :triple/vec   triple-vec-novar-noblank-spec
-        :triple/nform normal-form-novar-noblank-spec))
+  (s/or :triple/vec       triple-vec-novar-noblank-spec
+        :triple.nform/spo normal-form-novar-noblank-spec))
 
 ;; Collection of Triples
 
@@ -334,29 +329,29 @@
 ;; Collection of Quads (for UPDATE)
 
 (def quad-coll-nopath-spec
-  (s/coll-of (s/or :triple/vec         triple-vec-nopath-spec
-                   :triple/vec-no-po   triple-vec-no-po-nopath-spec
-                   :triple/nform       normal-form-nopath-spec
-                   :triple/nform-no-po normal-form-no-po-nopath-spec
-                   :triple/quads       quad-nopath-spec)
+  (s/coll-of (s/or :triple/vec       triple-vec-nopath-spec
+                   :triple/vec-no-po triple-vec-no-po-nopath-spec
+                   :triple.nform/spo normal-form-nopath-spec
+                   :triple.nform/s   normal-form-no-po-nopath-spec
+                   :triple/quads     quad-nopath-spec)
              :kind vector?))
 
 (def quad-coll-novar-spec
   (s/coll-of (s/or :triple/vec        triple-vec-novar-spec
                    :triple/vec-no-po  triple-vec-no-po-novar-spec
-                   :triple/nform      normal-form-novar-spec
-                   :triple/nform-list normal-form-no-po-novar-spec
+                   :triple.nform/spo      normal-form-novar-spec
+                   :triple.nform/s normal-form-no-po-novar-spec
                    :triple/quads      quad-novar-spec)
              :kind vector?))
 
 (def quad-coll-noblank-spec
   (s/coll-of (s/or :triple/vec   triple-vec-noblank-spec
-                   :triple/nform normal-form-noblank-spec
+                   :triple.nform/spo normal-form-noblank-spec
                    :triple/quads quad-noblank-spec)
              :kind vector?))
 
 (def quad-coll-novar-noblank-spec
   (s/coll-of (s/or :triple/vec   triple-vec-novar-noblank-spec
-                   :triple/nform normal-form-novar-noblank-spec
+                   :triple.nform/spo normal-form-novar-noblank-spec
                    :triple/quads quad-novar-noblank-spec)
              :kind vector?))

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -276,7 +276,7 @@
   (s/tuple ::subject-coll))
 
 (def triple-vec-no-po-nopath-spec
-  (s/tuple ::subject-coll))
+  (s/tuple ::subject-coll-nopath))
 
 (def triple-vec-no-po-novar-spec
   (s/tuple ::subject-coll-novar))

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -90,6 +90,12 @@
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/rdf-type   ax/rdf-type-spec))
 
+(s/def ::predicate-noblank
+  ::predicate-nopath)
+
+(s/def ::predicate-novar-noblank
+  ::predicate-novar)
+
 ;; Objects (includes Lists)
 
 (s/def ::object
@@ -115,8 +121,8 @@
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
         :ax/literal    ax/literal-spec
-        :triple/list   ::list-nopath
-        :triple/bnodes ::bnodes-nopath))
+        :triple/list   ::list-novar
+        :triple/bnodes ::bnodes-novar))
 
 (s/def ::object-noblank
   (s/or :ax/var        ax/variable-spec
@@ -212,10 +218,10 @@
   (make-pred-objs-spec ::predicate-novar obj-set-novar-spec))
 
 (def pred-objs-noblank-spec
-  (make-pred-objs-spec ::predicate-nopath obj-set-noblank-spec))
+  (make-pred-objs-spec ::predicate-noblank obj-set-noblank-spec))
 
 (def pred-objs-novar-noblank-spec
-  (make-pred-objs-spec ::predicate-novar obj-set-novar-noblank-spec))
+  (make-pred-objs-spec ::predicate-novar-noblank obj-set-novar-noblank-spec))
 
 ;; Subject Predicate Object
 
@@ -259,16 +265,16 @@
   (s/tuple ::subject ::predicate ::object))
 
 (def triple-vec-nopath-spec
-  (s/tuple ::subject ::predicate-nopath ::object))
+  (s/tuple ::subject-nopath ::predicate-nopath ::object-nopath))
 
 (def triple-vec-novar-spec
   (s/tuple ::subject-novar ::predicate-novar ::object-novar))
 
 (def triple-vec-noblank-spec
-  (s/tuple ::subject-noblank ::predicate-nopath ::object-noblank))
+  (s/tuple ::subject-noblank ::predicate-noblank ::object-noblank))
 
 (def triple-vec-novar-noblank-spec
-  (s/tuple ::subject-novar-noblank ::predicate-novar ::object-novar-noblank))
+  (s/tuple ::subject-novar-noblank ::predicate-novar-noblank ::object-novar-noblank))
 
 ;; Triple Vectors (Coll, no predicates + objects)
 

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -23,37 +23,6 @@
 ;; - DELETE DATA
 ;; - DELETE
 
-;; Lists
-
-;; List entries have the same spec as objects + `:triple/list`
-
-;; Since lists are constructed out of blank nodes, we do not allow list
-;; syntactic sugar (i.e. `:triple/list`) where blank nodes are banned.
-
-(declare list-spec)
-(declare list-novar-spec)
-
-(def list-entry-spec
-  (s/or :ax/var        ax/variable-spec
-        :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   list-spec))
-
-(def list-entry-novar-spec
-  (s/or :ax/iri        ax/iri-spec
-        :ax/prefix-iri ax/prefix-iri-spec
-        :ax/bnode      ax/bnode-spec
-        :ax/literal    ax/literal-spec
-        :triple/list   list-novar-spec))
-
-(def list-spec
-  (s/coll-of list-entry-spec :kind list?))
-
-(def list-novar-spec
-  (s/coll-of list-entry-novar-spec :kind list?))
-
 ;; Blank Node Vectors
 
 (declare pred-spec)
@@ -81,6 +50,51 @@
          (s/* (s/cat :pred pred-novar-spec :obj obj-novar-spec))
          (s/conformer conform-pred-obj-pairs)))
 
+;; Lists
+
+;; List entries have the same spec as objects + `:triple/list`
+
+;; Since lists are constructed out of blank nodes, we do not allow list
+;; syntactic sugar (i.e. `:triple/list`) where blank nodes are banned.
+
+(declare list-spec)
+(declare list-novar-spec)
+
+(def list-entry-spec
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   list-spec
+        :triple/bnodes bnode-vec-spec))
+
+(def list-entry-nopath-spec
+  (s/or :ax/var        ax/variable-spec
+        :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   list-spec
+        :triple/bnodes bnode-vec-nopath-spec))
+
+(def list-entry-novar-spec
+  (s/or :ax/iri        ax/iri-spec
+        :ax/prefix-iri ax/prefix-iri-spec
+        :ax/bnode      ax/bnode-spec
+        :ax/literal    ax/literal-spec
+        :triple/list   list-novar-spec
+        :triple/bnodes bnode-vec-novar-spec))
+
+(def list-spec
+  (s/coll-of list-entry-spec :kind list? :into []))
+
+(def list-nopath-spec
+  (s/coll-of list-entry-nopath-spec :kind list? :into []))
+
+(def list-novar-spec
+  (s/coll-of list-entry-novar-spec :kind list? :into []))
+
 ;; Subjects
 
 (def subj-spec
@@ -100,11 +114,11 @@
         :ax/iri        ax/iri-spec
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
-        :triple/list   list-spec
+        :triple/list   list-nopath-spec
         :triple/bnodes bnode-vec-nopath-spec))
 
 (def subj-coll-nopath-spec
-  (s/or :triple/list   list-spec
+  (s/or :triple/list   list-nopath-spec
         :triple/bnodes bnode-vec-nopath-spec))
 
 (def subj-novar-spec
@@ -164,7 +178,7 @@
         :ax/prefix-iri ax/prefix-iri-spec
         :ax/bnode      ax/bnode-spec
         :ax/literal    ax/literal-spec
-        :triple/list   list-spec
+        :triple/list   list-nopath-spec
         :triple/bnodes bnode-vec-nopath-spec))
 
 (def obj-novar-spec

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -135,17 +135,25 @@
 
 #?(:clj
    (defmacro make-obj-spec
-     [obj-spec]
-     `(s/or :triple/o (s/coll-of ~obj-spec
-                                 :min-count 1
-                                 :kind set?
-                                 :into []))))
+     ([obj-spec]
+      `(s/or :triple/o
+             (s/coll-of (s/or :triple/object ~obj-spec)
+                        :min-count 1
+                        :kind set?
+                        :into [])))
+     ([obj-spec obj-list-spec]
+      `(s/or :triple/o
+             (s/coll-of (s/or :triple/object ~obj-spec
+                              :triple/list ~obj-list-spec)
+                        :min-count 1
+                        :kind set?
+                        :into [])))))
 
 (def obj-set-spec
-  (make-obj-spec obj-spec))
+  (make-obj-spec obj-spec list-spec))
 
 (def obj-set-novar-spec
-  (make-obj-spec obj-novar-spec))
+  (make-obj-spec obj-novar-spec list-novar-spec))
 
 (def obj-set-noblank-spec
   (make-obj-spec obj-noblank-spec))

--- a/src/main/com/yetanalytics/flint/spec/triple.cljc
+++ b/src/main/com/yetanalytics/flint/spec/triple.cljc
@@ -167,7 +167,6 @@
    (defmacro make-pred-objs-spec
      [pred-spec objs-spec]
      `(s/or :triple/po (s/map-of ~pred-spec ~objs-spec
-                                 :min-count 1
                                  :into []))))
 
 (def pred-objs-spec
@@ -189,19 +188,26 @@
 
 #?(:clj
    (defmacro make-nform-spec
-     [subj-spec pred-objs-spec]
-     `(s/or :triple/spo (s/map-of ~subj-spec ~pred-objs-spec
-                                  :conform-keys true
-                                  :into []))))
+     ([subj-spec pred-objs-spec]
+      `(s/or :triple/spo
+             (s/map-of ~subj-spec (s/and ~pred-objs-spec not-empty)
+                       :conform-keys true :into [])))
+     ([subj-spec subj-list-spec pred-objs-spec]
+      `(s/or :triple/spo
+             (s/map-of ~subj-spec (s/and ~pred-objs-spec not-empty)
+                       :conform-keys true :into [])
+             :triple/spo-list
+             (s/map-of ~subj-list-spec ~pred-objs-spec
+                       :conform-keys true :into [])))))
 
 (def normal-form-spec
-  (make-nform-spec subj-spec pred-objs-spec))
+  (make-nform-spec subj-spec list-spec pred-objs-spec))
 
 (def normal-form-nopath-spec
-  (make-nform-spec subj-spec pred-objs-nopath-spec))
+  (make-nform-spec subj-spec list-spec pred-objs-nopath-spec))
 
 (def normal-form-novar-spec
-  (make-nform-spec subj-novar-spec pred-objs-novar-spec))
+  (make-nform-spec subj-novar-spec list-novar-spec pred-objs-novar-spec))
 
 (def normal-form-noblank-spec
   (make-nform-spec subj-noblank-spec pred-objs-noblank-spec))

--- a/src/main/com/yetanalytics/flint/spec/update.cljc
+++ b/src/main/com/yetanalytics/flint/spec/update.cljc
@@ -46,78 +46,6 @@
     (- n1 n2)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Quad specs
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(def triples-spec
-  (s/coll-of (s/or :triple/vec ts/triple-vec-nopath-spec
-                   :triple/nform ts/normal-form-nopath-spec)
-             :kind vector?))
-
-(def triples-novar-spec
-  (s/coll-of (s/or :triple/vec ts/triple-vec-novar-spec
-                   :triple/nform ts/normal-form-novar-spec)
-             :kind vector?))
-
-(def triples-noblank-spec
-  (s/coll-of (s/or :triple/vec ts/triple-vec-noblank-spec
-                   :triple/nform ts/normal-form-noblank-spec)
-             :kind vector?))
-
-(def triples-novar-noblank-spec
-  (s/coll-of (s/or :triple/vec ts/triple-vec-novar-noblank-spec
-                   :triple/nform ts/normal-form-novar-noblank-spec)
-             :kind vector?))
-
-(def quad-spec
-  (s/and (s/tuple #{:graph}
-                  ax/iri-or-var-spec
-                  (s/or :triple/quad-triples triples-spec))
-         (s/conformer (fn [[_ iri t]] [iri t]))))
-
-(def quad-novar-spec
-  (s/and (s/tuple #{:graph}
-                  ax/iri-or-var-spec
-                  (s/or :triple/quad-triples triples-novar-spec))
-         (s/conformer (fn [[_ iri t]] [iri t]))))
-
-(def quad-noblank-spec
-  (s/and (s/tuple #{:graph}
-                  ax/iri-or-var-spec
-                  (s/or :triple/quad-triples triples-noblank-spec))
-         (s/conformer (fn [[_ iri t]] [iri t]))))
-
-(def quad-novar-noblank-spec
-  (s/and (s/tuple #{:graph}
-                  ax/iri-or-var-spec
-                  (s/or :triple/quad-triples triples-novar-noblank-spec))
-         (s/conformer (fn [[_ iri t]] [iri t]))))
-
-(def triple-or-quads-spec
-  (s/coll-of (s/or :triple/vec  ts/triple-vec-nopath-spec
-                   :triple/nform ts/normal-form-nopath-spec
-                   :triple/quads quad-spec)
-             :kind vector?))
-
-(def triple-or-quads-novar-spec
-  (s/coll-of (s/or :triple/vec  ts/triple-vec-novar-spec
-                   :triple/nform ts/normal-form-novar-spec
-                   :triple/quads quad-novar-spec)
-             :kind vector?))
-
-(def triple-or-quads-noblank-spec
-  (s/coll-of (s/or :triple/vec  ts/triple-vec-noblank-spec
-                   :triple/nform ts/normal-form-noblank-spec
-                   :triple/quads quad-noblank-spec)
-             :kind vector?))
-
-(def triple-or-quads-novar-noblank-spec
-  (s/coll-of (s/or :triple/vec  ts/triple-vec-novar-noblank-spec
-                   :triple/nform ts/normal-form-novar-noblank-spec
-                   :triple/quads quad-novar-noblank-spec)
-             :kind vector?))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Graph Management specs
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -221,7 +149,7 @@
 
 ;; INSERT DATA
 
-(s/def ::insert-data triple-or-quads-novar-spec)
+(s/def ::insert-data ts/quad-coll-novar-spec)
 
 (def insert-data-update-spec
   (sparql-keys :req-un [::insert-data]
@@ -230,7 +158,7 @@
 
 ;; DELETE DATA
 
-(s/def ::delete-data triple-or-quads-novar-noblank-spec)
+(s/def ::delete-data ts/quad-coll-novar-noblank-spec)
 
 (def delete-data-update-spec
   (sparql-keys :req-un [::delete-data]
@@ -239,7 +167,7 @@
 
 ;; DELETE WHERE
 
-(s/def ::delete-where triple-or-quads-noblank-spec)
+(s/def ::delete-where ts/quad-coll-noblank-spec)
 
 (def delete-where-update-spec
   (sparql-keys :req-un [::delete-where]
@@ -254,8 +182,8 @@
   (s/or :update/iri ax/iri-or-prefixed-spec
         :update/named-iri (s/tuple #{:named} ax/iri-or-prefixed-spec)))
 
-(s/def ::insert triple-or-quads-spec)
-(s/def ::delete triple-or-quads-noblank-spec)
+(s/def ::insert ts/quad-coll-nopath-spec)
+(s/def ::delete ts/quad-coll-noblank-spec)
 
 (def modify-update-spec
   (sparql-keys :req-un [(or ::delete ::insert)

--- a/src/main/com/yetanalytics/flint/spec/where.cljc
+++ b/src/main/com/yetanalytics/flint/spec/where.cljc
@@ -110,19 +110,24 @@
               :v ::vs/values)
        (s/conformer (fn [{:keys [v]}] [:where/values v]))))
 
+(defmethod where-special-form-mm :default [_]
+  (constantly false))
+
 (def where-special-form-spec
   "Specs for special WHERE forms/graph patterns, which should be
    of the form `[:keyword ...]`."
-  (s/and vector? (s/multi-spec where-special-form-mm first)))
+  (s/and vector?
+         #(keyword? (first %))
+         (s/multi-spec where-special-form-mm first)))
+
+(def where-spec
+  (s/or :where/special where-special-form-spec
+        :where/triple  ts/triple-spec))
 
 (s/def ::where
   (s/or :where-sub/select
         ::select
         :where-sub/where
-        (s/coll-of (s/or :where/special where-special-form-spec
-                         :triple/vec    ts/triple-vec-spec
-                         :triple/nform  ts/normal-form-spec)
-                   :min-count 1
-                   :kind vector?)
+        (s/coll-of where-spec :min-count 1 :kind vector?)
         :where-sub/empty
         (s/and vector? empty?)))

--- a/src/main/com/yetanalytics/flint/validate.cljc
+++ b/src/main/com/yetanalytics/flint/validate.cljc
@@ -49,12 +49,15 @@
 (defn- ast-children
   [[k children]]
   (cond
+    ;; These values are colls of colls
     (#{:triple.nform/spo :triple.nform/po} k)
     (apply concat children)
+    ;; These values are either AST nodes or scalars
     (or (and (vector? children)
              (keyword? (first children)))
         (not (coll? children)))
     [children]
+    ;; These values are colls of AST nodes
     :else
     children))
 

--- a/src/main/com/yetanalytics/flint/validate.cljc
+++ b/src/main/com/yetanalytics/flint/validate.cljc
@@ -9,7 +9,7 @@
    subquery):
    
      [:where/triple
-      [:triple/vec ...]]     => 0
+      [:triple.vec/spo ...]]     => 0
      [:where/triple
       [:triple.nform/spo ...]]   => 0
      [:where/special

--- a/src/main/com/yetanalytics/flint/validate.cljc
+++ b/src/main/com/yetanalytics/flint/validate.cljc
@@ -49,8 +49,8 @@
 (defn- ast-children
   [[k children]]
   (cond
-    ;; These values are colls of colls
-    (#{:triple.nform/spo :triple.nform/po} k)
+    ;; These values are colls of non-AST colls
+    (#{:triple/bnodes :triple.nform/spo :triple.nform/po} k)
     (apply concat children)
     ;; These values are either AST nodes or scalars
     (or (and (vector? children)

--- a/src/main/com/yetanalytics/flint/validate.cljc
+++ b/src/main/com/yetanalytics/flint/validate.cljc
@@ -11,13 +11,13 @@
      [:where/triple
       [:triple/vec ...]]     => 0
      [:where/triple
-      [:triple/nform ...]]   => 0
+      [:triple.nform/spo ...]]   => 0
      [:where/special
       [:where/filter ...]]   => 0 ; FILTERs don't divide BGPs
      [:where/special
       [:where/optional ...]] => X ; BGP divider
      [:where/triple
-      [:triple/nform ...]]   => 1
+      [:triple.nform/spo ...]]   => 1
    "
   [loc]
   (let [?left-node (some-> loc zip/left zip/node)
@@ -49,7 +49,7 @@
 (defn- ast-children
   [[k children]]
   (cond
-    (#{:triple/spo :triple/po} k)
+    (#{:triple.nform/spo :triple.nform/po} k)
     (apply concat children)
     (or (and (vector? children)
              (keyword? (first children)))

--- a/src/main/com/yetanalytics/flint/validate.cljc
+++ b/src/main/com/yetanalytics/flint/validate.cljc
@@ -4,7 +4,21 @@
             [com.yetanalytics.flint.util :as u]))
 
 (defn- bgp-divider?
-  "Is `ast-node` a divider between BGPs?"
+  "Is `ast-node` a divider between BGPs? BGPs are divided by `:where/special`
+   clauses, with the exception of filters (unless they themselves have a
+   subquery):
+   
+     [:where/triple
+      [:triple/vec ...]]     => 0
+     [:where/triple
+      [:triple/nform ...]]   => 0
+     [:where/special
+      [:where/filter ...]]   => 0 ; FILTERs don't divide BGPs
+     [:where/special
+      [:where/optional ...]] => X ; BGP divider
+     [:where/triple
+      [:triple/nform ...]]   => 1
+   "
   [loc]
   (let [?left-node (some-> loc zip/left zip/node)
         ?curr-node (some-> loc zip/node)]

--- a/src/main/com/yetanalytics/flint/validate.cljc
+++ b/src/main/com/yetanalytics/flint/validate.cljc
@@ -3,6 +3,24 @@
             [com.yetanalytics.flint.spec.expr :as es]
             [com.yetanalytics.flint.util :as u]))
 
+(defn- bgp-divider?
+  "Is `ast-node` a divider between BGPs?"
+  [loc]
+  (let [?left-node (some-> loc zip/left zip/node)
+        ?curr-node (some-> loc zip/node)]
+    (or
+     ;; BGPs are separated by special clauses, with the exception of FILTER...
+     (and (some-> ?left-node (get-in [0]) (= :where/special))
+          (some-> ?left-node (get-in [1 0]) (not= :where/filter)))
+     ;; BGPs are also separated via nesting (which also separates BGPs at the
+     ;; top level)
+     (some-> ?curr-node (get-in [0]) (= :where-sub/where))
+     ;; ...including the case of FILTER (NOT) EXISTS, which has its own BGP
+     ;; as a subquery (c.f. MINUS)
+     (and (some-> ?curr-node (get-in [0]) (= :expr/branch))
+          (or (some-> ?curr-node (get-in [1 0]) (= [:expr/op 'exists]))
+              (some-> ?curr-node (get-in [1 0]) (= [:expr/op 'not-exists])))))))
+
 (def axiom-keys
   #{:ax/iri :ax/prefix-iri :ax/var :ax/bnode :ax/wildcard :ax/rdf-type
     :ax/str-lit :ax/lmap-list :ax/num-lit :ax/bool-lit :ax/dt-lit
@@ -65,22 +83,37 @@
 
 (defn collect-nodes
   [ast]
-  (loop [loc    (ast-zipper ast)
-         node-m {}]
+  (loop [loc     (ast-zipper ast)
+         node-m  {}
+         bgp-idx 0]
     (if-not (zip/end? loc)
-      (let [ast-node (zip/node loc)]
+      (let [ast-node (zip/node loc)
+            bgp-idx* (cond-> bgp-idx (bgp-divider? loc) inc)]
         (if-some [k (u/get-keyword ast-node)]
           (cond
-            ;; Prefixes, blank nodes, and BIND clauses
-            (node-keys k)
-            (recur (zip/next loc)
-                   (update-in node-m [k (second ast-node)] conj loc))
+            ;; Prefixes, BIND (expr AS var), and SELECT ... (expr AS var) ...
+            (#{:ax/prefix-iri :where/bind :select/expr-as-var} k)
+            (let [v (second ast-node)]
+              (recur (zip/next loc)
+                     (update-in node-m [k v] conj loc)
+                     bgp-idx*))
+            ;; Blank nodes
+            (#{:ax/bnode} k)
+            (let [bnode     (second ast-node)
+                  top-level (-> loc zip/path second first)
+                  bgp-path  (cond-> [top-level]
+                              (= :where top-level)
+                              (conj bgp-idx*))]
+              (recur (zip/next loc)
+                     (update-in node-m [k bnode bgp-path] conj loc)
+                     bgp-idx*))
             ;; SELECT with GROUP BY
             (#{:group-by} k)
             (let [select-loc (zip/up loc)
                   select     (zip/node select-loc)]
               (recur (zip/next loc)
-                     (update node-m :agg/select assoc select select-loc)))
+                     (update node-m :agg/select assoc select select-loc)
+                     bgp-idx*))
             ;; SELECT with an aggregate expression
             (#{:expr/branch} k)
             (let [op (-> ast-node ; [:expr/branch ...]
@@ -97,9 +130,9 @@
                                          assoc
                                          select
                                          select-loc)]
-                  (recur (zip/next loc) node-m*))
-                (recur (zip/next loc) node-m)))
+                  (recur (zip/next loc) node-m* bgp-idx*))
+                (recur (zip/next loc) node-m bgp-idx*)))
             :else
-            (recur (zip/next loc) node-m))
-          (recur (zip/next loc) node-m)))
+            (recur (zip/next loc) node-m bgp-idx*))
+          (recur (zip/next loc) node-m bgp-idx*)))
       node-m)))

--- a/src/main/com/yetanalytics/flint/validate/aggregate.cljc
+++ b/src/main/com/yetanalytics/flint/validate/aggregate.cljc
@@ -9,7 +9,7 @@
 ;; just a variable, those variables may be projected from the level.
 
 ;; GOOD:
-;;   SELECT (2 AS ?two) WHER { ?x ?y ?z }
+;;   SELECT (2 AS ?two) WHERE { ?x ?y ?z }
 ;;   SELECT (SUM(?x) AS ?sum) WHERE { ?x ?y ?z }
 ;;   SELECT ?x WHERE { ?x ?y ?z } GROUP BY ?x
 

--- a/src/main/com/yetanalytics/flint/validate/aggregate.cljc
+++ b/src/main/com/yetanalytics/flint/validate/aggregate.cljc
@@ -1,7 +1,7 @@
 (ns com.yetanalytics.flint.validate.aggregate
-  (:require [clojure.zip :as zip]
-            [com.yetanalytics.flint.validate.variable :as vv]
-            [com.yetanalytics.flint.util              :as u]))
+  (:require [com.yetanalytics.flint.validate.variable :as vv]
+            [com.yetanalytics.flint.util              :as u]
+            [com.yetanalytics.flint.validate.util     :as vu]))
 
 ;; In a query level which uses aggregates, only expressions consisting of
 ;; aggregates and constants may be projected, with one exception.
@@ -57,12 +57,12 @@
     (case sel-k
       :ax/wildcard
       {:kind ::wildcard-group-by
-       :path (->> loc zip/path (mapv first))}
+       :path (vu/zip-path loc)}
       :select/var-or-exprs
       (when-some [bad-vars (validate-agg-select-clause group-by-vs sel-v)]
         {:kind      ::invalid-aggregate-var
          :variables bad-vars
-         :path      (->> loc zip/path (mapv first))})
+         :path      (vu/zip-path loc)})
       ;; else - perhaps it is a CONSTRUCT, DESCRIBE, or ASK query instead
       nil)))
 

--- a/src/main/com/yetanalytics/flint/validate/bnode.cljc
+++ b/src/main/com/yetanalytics/flint/validate/bnode.cljc
@@ -32,7 +32,13 @@
       (-> loc    ; [:ax/bnode ...]
           zip/up ; [:triple/spo ...]
           zip/up ; [:triple/nform ...]
-          ))))
+          )
+      :triple/spo-list
+      (-> loc    ; [:ax/bnode ...]
+          zip/up ; [:triple/spo-list ...]
+          zip/up ; [:triple/nform ...]
+          )
+      )))
 
 (defn- bgp-divider?
   [ast-node]

--- a/src/main/com/yetanalytics/flint/validate/bnode.cljc
+++ b/src/main/com/yetanalytics/flint/validate/bnode.cljc
@@ -12,8 +12,17 @@
       (-> loc    ; [:ax/bnode ...]
           zip/up ; [:triple/vec ...]
           )
-      :triple/o
+      :triple/list
       (-> loc    ; [:ax/bnode ...]
+          zip/up ; [:triple/list ...]
+          zip/up ; [:triple/o ...]
+          zip/up ; [:triple/po ...]
+          zip/up ; [:triple/spo ...]
+          zip/up ; [:triple/nform ...]
+          )
+      :triple/object
+      (-> loc    ; [:ax/bnode ...]
+          zip/up ; [:triple/object ...]
           zip/up ; [:triple/o ...]
           zip/up ; [:triple/po ...]
           zip/up ; [:triple/spo ...]

--- a/src/main/com/yetanalytics/flint/validate/prefix.cljc
+++ b/src/main/com/yetanalytics/flint/validate/prefix.cljc
@@ -1,5 +1,5 @@
 (ns com.yetanalytics.flint.validate.prefix
-  (:require [clojure.zip :as zip]))
+  (:require [com.yetanalytics.flint.validate.util :as vu]))
 
 (defn- invalid-prefix?
   "Does the prefix of `prefix-iri` exist in the `prefixes` map/set?
@@ -14,7 +14,7 @@
   {:prefixes prefixes
    :iri      prefix-iri
    :prefix   (or (some->> prefix-iri namespace keyword) :$)
-   :path     (conj (->> loc zip/path (mapv first)) :ax/prefix-iri)})
+   :path     (conj (vu/zip-path loc) :ax/prefix-iri)})
 
 (defn validate-prefixes
   "Given `node-m` a map from nodes to zipper locs, check that each prefix

--- a/src/main/com/yetanalytics/flint/validate/scope.cljc
+++ b/src/main/com/yetanalytics/flint/validate/scope.cljc
@@ -1,6 +1,7 @@
 (ns com.yetanalytics.flint.validate.scope
   (:require [clojure.zip :as zip]
             [com.yetanalytics.flint.validate.variable :as vv]
+            [com.yetanalytics.flint.validate.util     :as vu]
             [com.yetanalytics.flint.util              :as u]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -12,14 +13,14 @@
   {:kind       ::var-in-scope
    :variable   var
    :scope-vars scope-vars
-   :path       (conj (->> zip-loc zip/path (mapv first)) k)})
+   :path       (conj (vu/zip-path zip-loc) k)})
 
 (defn- not-in-scope-err-map
   [vars scope-vars zip-loc k]
   {:kind       ::var-not-in-scope
    :variables  vars
    :scope-vars scope-vars
-   :path       (conj (->> zip-loc zip/path (mapv first)) k)})
+   :path       (conj (vu/zip-path zip-loc) k)})
 
 (defn- validate-bind
   "Validate `BIND (expr AS var)` in WHERE clauses."

--- a/src/main/com/yetanalytics/flint/validate/util.cljc
+++ b/src/main/com/yetanalytics/flint/validate/util.cljc
@@ -1,0 +1,7 @@
+(ns com.yetanalytics.flint.validate.util
+  (:require [clojure.zip :as zip]))
+
+(defn zip-path
+  "Return the path vector (excluding array indices) that leads up to `loc`."
+  [loc]
+  (->> loc zip/path (mapv first)))

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -123,6 +123,14 @@
              []
              spo))
 
+(defmethod get-scope-vars :triple/spo-list [[_ spo]]
+  (reduce-kv (fn [acc s po] (apply concat
+                                   acc
+                                   (mapcat get-scope-vars s)
+                                   (map get-scope-vars po)))
+             []
+             spo))
+
 (defmethod get-scope-vars :triple/nform [[_ nform]]
   (get-scope-vars nform))
 

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -95,6 +95,12 @@
 
 ;; Basic Graph Pattern
 
+(defmethod get-scope-vars :triple/object [[_ object]]
+  (get-scope-vars object))
+
+(defmethod get-scope-vars :triple/list [[_ list]]
+  (mapcat get-scope-vars list))
+
 (defmethod get-scope-vars :triple/vec [[_ spo]]
   (mapcat get-scope-vars spo))
 
@@ -181,4 +187,3 @@
 
 (defmethod get-scope-vars :where/values [[_ [_ values]]]
   (mapcat get-scope-vars (first values)))
-

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -130,9 +130,6 @@
              []
              spo-pairs))
 
-(defmethod get-scope-vars :triple.nform/s [[_ s]]
-  (get-scope-vars s))
-
 ;; Path
 
 (defmethod get-scope-vars :triple/path [[_ p]]

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -147,6 +147,9 @@
 
 ;; Group
 
+(defmethod get-scope-vars :where/triple [[_ vs]]
+  (get-scope-vars vs))
+
 (defmethod get-scope-vars :where/special [[_ vs]]
   (get-scope-vars vs))
 

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -98,8 +98,11 @@
 (defmethod get-scope-vars :triple/list [[_ list]]
   (mapcat get-scope-vars list))
 
-(defmethod get-scope-vars :triple/vec [[_ spo]]
+(defmethod get-scope-vars :triple.vec/spo [[_ spo]]
   (mapcat get-scope-vars spo))
+
+(defmethod get-scope-vars :triple.vec/s [[_ s]]
+  (get-scope-vars s))
 
 (defmethod get-scope-vars :triple.nform/o [[_ o]]
   (mapcat get-scope-vars o))

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -101,10 +101,10 @@
 (defmethod get-scope-vars :triple/vec [[_ spo]]
   (mapcat get-scope-vars spo))
 
-(defmethod get-scope-vars :triple/o [[_ o]]
+(defmethod get-scope-vars :triple.nform/o [[_ o]]
   (mapcat get-scope-vars o))
 
-(defmethod get-scope-vars :triple/po [[_ po]]
+(defmethod get-scope-vars :triple.nform/po [[_ po]]
   (reduce-kv (fn [acc p o] (apply concat
                                   acc
                                   (get-scope-vars p)
@@ -112,7 +112,7 @@
              []
              po))
 
-(defmethod get-scope-vars :triple/spo [[_ spo]]
+(defmethod get-scope-vars :triple.nform/spo [[_ spo]]
   (reduce-kv (fn [acc s po] (apply concat
                                    acc
                                    (get-scope-vars s)
@@ -120,16 +120,8 @@
              []
              spo))
 
-(defmethod get-scope-vars :triple/spo-list [[_ spo]]
-  (reduce-kv (fn [acc s po] (apply concat
-                                   acc
-                                   (mapcat get-scope-vars s)
-                                   (map get-scope-vars po)))
-             []
-             spo))
-
-(defmethod get-scope-vars :triple/nform [[_ nform]]
-  (get-scope-vars nform))
+(defmethod get-scope-vars :triple.nform/s [[_ s]]
+  (get-scope-vars s))
 
 ;; Path
 

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -98,30 +98,37 @@
 (defmethod get-scope-vars :triple/list [[_ list]]
   (mapcat get-scope-vars list))
 
+(defmethod get-scope-vars :triple/bnodes [[_ po-pairs]]
+  (mapcat (fn [[p o]] (concat (get-scope-vars p)
+                              (get-scope-vars o)))
+          po-pairs))
+
+(mapcat get-scope-vars '[[[:ax/var ?z1] [:ax/var ?z2]]])
+
 (defmethod get-scope-vars :triple.vec/spo [[_ spo]]
   (mapcat get-scope-vars spo))
 
 (defmethod get-scope-vars :triple.vec/s [[_ s]]
   (get-scope-vars s))
 
-(defmethod get-scope-vars :triple.nform/o [[_ o]]
-  (mapcat get-scope-vars o))
+(defmethod get-scope-vars :triple.nform/o [[_ o-coll]]
+  (mapcat get-scope-vars o-coll))
 
-(defmethod get-scope-vars :triple.nform/po [[_ po]]
-  (reduce-kv (fn [acc p o] (apply concat
-                                  acc
-                                  (get-scope-vars p)
-                                  (map get-scope-vars o)))
+(defmethod get-scope-vars :triple.nform/po [[_ po-pairs]]
+  (reduce-kv (fn [acc p o-coll] (apply concat
+                                       acc
+                                       (get-scope-vars p)
+                                       (map get-scope-vars o-coll)))
              []
-             po))
+             po-pairs))
 
-(defmethod get-scope-vars :triple.nform/spo [[_ spo]]
+(defmethod get-scope-vars :triple.nform/spo [[_ spo-pairs]]
   (reduce-kv (fn [acc s po] (apply concat
                                    acc
                                    (get-scope-vars s)
                                    (map get-scope-vars po)))
              []
-             spo))
+             spo-pairs))
 
 (defmethod get-scope-vars :triple.nform/s [[_ s]]
   (get-scope-vars s))

--- a/src/main/com/yetanalytics/flint/validate/variable.cljc
+++ b/src/main/com/yetanalytics/flint/validate/variable.cljc
@@ -95,9 +95,6 @@
 
 ;; Basic Graph Pattern
 
-(defmethod get-scope-vars :triple/object [[_ object]]
-  (get-scope-vars object))
-
 (defmethod get-scope-vars :triple/list [[_ list]]
   (mapcat get-scope-vars list))
 

--- a/src/test/com/yetanalytics/flint/format/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/expr_test.cljc
@@ -180,17 +180,17 @@
            (->> '[:expr/branch [[:expr/op exists]
                                 [:expr/args [[:where-sub/where
                                               [:where/triple
-                                               [[:triple/vec [[:ax/var ?x]
-                                                              [:ax/var ?y]
-                                                              [:ax/var ?z]]]]]]]]]]
+                                               [[:triple.vec/spo [[:ax/var ?x]
+                                                                  [:ax/var ?y]
+                                                                  [:ax/var ?z]]]]]]]]]]
                 format-ast)))
     (is (= "NOT EXISTS {\n    ?x ?y ?z .\n}"
            (->> '[:expr/branch [[:expr/op not-exists]
                                 [:expr/args [[:where-sub/where
                                               [[:where/triple
-                                                [:triple/vec [[:ax/var ?x]
-                                                              [:ax/var ?y]
-                                                              [:ax/var ?z]]]]]]]]]]
+                                                [:triple.vec/spo [[:ax/var ?x]
+                                                                  [:ax/var ?y]
+                                                                  [:ax/var ?z]]]]]]]]]]
                 format-ast)))))
 
 (deftest format-expr-as-var-test

--- a/src/test/com/yetanalytics/flint/format/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/expr_test.cljc
@@ -179,16 +179,18 @@
     (is (= "EXISTS {\n    ?x ?y ?z .\n}"
            (->> '[:expr/branch [[:expr/op exists]
                                 [:expr/args [[:where-sub/where
-                                              [[:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]]]
+                                              [:where/triple
+                                               [[:triple/vec [[:ax/var ?x]
+                                                              [:ax/var ?y]
+                                                              [:ax/var ?z]]]]]]]]]]
                 format-ast)))
     (is (= "NOT EXISTS {\n    ?x ?y ?z .\n}"
            (->> '[:expr/branch [[:expr/op not-exists]
                                 [:expr/args [[:where-sub/where
-                                              [[:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]]]
+                                              [[:where/triple
+                                                [:triple/vec [[:ax/var ?x]
+                                                              [:ax/var ?y]
+                                                              [:ax/var ?z]]]]]]]]]]
                 format-ast)))))
 
 (deftest format-expr-as-var-test

--- a/src/test/com/yetanalytics/flint/format/query_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/query_test.cljc
@@ -24,9 +24,9 @@
                    [:select [:select/var-or-exprs [[:ax/var ?x]]]]
                    [:from [:ax/iri "<http://example.org/my-graph/>"]]
                    [:where [:where-sub/where [[:where/triple
-                                               [:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]
+                                               [:triple.vec/spo [[:ax/var ?x]
+                                                                 [:ax/var ?y]
+                                                                 [:ax/var ?z]]]]]]]
                    [:order-by [[:mod/asc-desc
                                 [[:mod/op asc]
                                  [:mod/asc-desc-expr [:expr/terminal [:ax/var ?y]]]]]]]
@@ -43,14 +43,14 @@
                             "    ?x ?y ?z ."
                             "}"])
            (->> '[:query/construct
-                  [[:construct [[:triple/vec [[:ax/var ?x]
-                                              [:ax/var ?y]
-                                              [:ax/var ?z]]]]]
+                  [[:construct [[:triple.vec/spo [[:ax/var ?x]
+                                                  [:ax/var ?y]
+                                                  [:ax/var ?z]]]]]
                    [:from [:ax/iri "<http://example.org/my-graph/>"]]
                    [:where [:where-sub/where [[:where/triple
-                                               [:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]]]
+                                               [:triple.vec/spo [[:ax/var ?x]
+                                                                 [:ax/var ?y]
+                                                                 [:ax/var ?z]]]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["CONSTRUCT"
                             "FROM <http://example.org/my-graph/>"
@@ -61,9 +61,9 @@
                   [[:construct []]
                    [:from [:ax/iri "<http://example.org/my-graph/>"]]
                    [:where [:where-sub/where [[:where/triple
-                                               [:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]]]
+                                               [:triple.vec/spo [[:ax/var ?x]
+                                                                 [:ax/var ?y]
+                                                                 [:ax/var ?z]]]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["CONSTRUCT"
                             "WHERE {"
@@ -72,9 +72,9 @@
            (->> '[:query/construct
                   [[:construct []]
                    [:where [:where-sub/where [[:where/triple
-                                               [:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]]]
+                                               [:triple.vec/spo [[:ax/var ?x]
+                                                                 [:ax/var ?y]
+                                                                 [:ax/var ?z]]]]]]]]]
                 format-ast))))
   (testing "Formatting DESCRIBE queries"
     (is (= (cstr/join "\n" ["DESCRIBE ?x ?y"
@@ -88,9 +88,9 @@
                    [:from-named [[:ax/iri "<http://example.org/my-graph/>"]
                                  [:ax/iri "<http://example.org/my-graph-2/>"]]]
                    [:where [:where-sub/where [[:where/triple
-                                               [:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]]]
+                                               [:triple.vec/spo [[:ax/var ?x]
+                                                                 [:ax/var ?y]
+                                                                 [:ax/var ?z]]]]]]]]]
                 format-ast))))
   (testing "Formatting ASK queries"
     (is (= (cstr/join "\n" ["ASK"
@@ -104,9 +104,9 @@
                    [:from-named [[:ax/iri "<http://example.org/my-graph/>"]
                                  [:ax/iri "<http://example.org/my-graph-2/>"]]]
                    [:where [:where-sub/where [[:where/triple
-                                               [:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]]]
+                                               [:triple.vec/spo [[:ax/var ?x]
+                                                                 [:ax/var ?y]
+                                                                 [:ax/var ?z]]]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["ASK"
                             "WHERE {"
@@ -115,7 +115,7 @@
            (->> '[:query/ask
                   [[:ask []]
                    [:where [:where-sub/where [[:where/triple
-                                               [:triple/vec [[:ax/var ?x]
-                                                             [:ax/var ?y]
-                                                             [:ax/var ?z]]]]]]]]]
+                                               [:triple.vec/spo [[:ax/var ?x]
+                                                                 [:ax/var ?y]
+                                                                 [:ax/var ?z]]]]]]]]]
                 format-ast)))))

--- a/src/test/com/yetanalytics/flint/format/query_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/query_test.cljc
@@ -23,9 +23,10 @@
                   [[:prefixes [[:prologue/prefix [[:ax/prefix :foo] [:ax/iri "<http://example.org/foo/>"]]]]]
                    [:select [:select/var-or-exprs [[:ax/var ?x]]]]
                    [:from [:ax/iri "<http://example.org/my-graph/>"]]
-                   [:where [:where-sub/where [[:triple/vec [[:ax/var ?x]
-                                                            [:ax/var ?y]
-                                                            [:ax/var ?z]]]]]]
+                   [:where [:where-sub/where [[:where/triple
+                                               [:triple/vec [[:ax/var ?x]
+                                                             [:ax/var ?y]
+                                                             [:ax/var ?z]]]]]]]
                    [:order-by [[:mod/asc-desc
                                 [[:mod/op asc]
                                  [:mod/asc-desc-expr [:expr/terminal [:ax/var ?y]]]]]]]
@@ -46,9 +47,10 @@
                                               [:ax/var ?y]
                                               [:ax/var ?z]]]]]
                    [:from [:ax/iri "<http://example.org/my-graph/>"]]
-                   [:where [:where-sub/where [[:triple/vec [[:ax/var ?x]
-                                                            [:ax/var ?y]
-                                                            [:ax/var ?z]]]]]]]]
+                   [:where [:where-sub/where [[:where/triple
+                                               [:triple/vec [[:ax/var ?x]
+                                                             [:ax/var ?y]
+                                                             [:ax/var ?z]]]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["CONSTRUCT"
                             "FROM <http://example.org/my-graph/>"
@@ -58,9 +60,10 @@
            (->> '[:query/construct
                   [[:construct []]
                    [:from [:ax/iri "<http://example.org/my-graph/>"]]
-                   [:where [:where-sub/where [[:triple/vec [[:ax/var ?x]
-                                                            [:ax/var ?y]
-                                                            [:ax/var ?z]]]]]]]]
+                   [:where [:where-sub/where [[:where/triple
+                                               [:triple/vec [[:ax/var ?x]
+                                                             [:ax/var ?y]
+                                                             [:ax/var ?z]]]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["CONSTRUCT"
                             "WHERE {"
@@ -68,9 +71,10 @@
                             "}"])
            (->> '[:query/construct
                   [[:construct []]
-                   [:where [:where-sub/where [[:triple/vec [[:ax/var ?x]
-                                                            [:ax/var ?y]
-                                                            [:ax/var ?z]]]]]]]]
+                   [:where [:where-sub/where [[:where/triple
+                                               [:triple/vec [[:ax/var ?x]
+                                                             [:ax/var ?y]
+                                                             [:ax/var ?z]]]]]]]]]
                 format-ast))))
   (testing "Formatting DESCRIBE queries"
     (is (= (cstr/join "\n" ["DESCRIBE ?x ?y"
@@ -83,9 +87,10 @@
                   [[:describe [:describe/vars-or-iris [[:ax/var ?x] [:ax/var ?y]]]]
                    [:from-named [[:ax/iri "<http://example.org/my-graph/>"]
                                  [:ax/iri "<http://example.org/my-graph-2/>"]]]
-                   [:where [:where-sub/where [[:triple/vec [[:ax/var ?x]
-                                                            [:ax/var ?y]
-                                                            [:ax/var ?z]]]]]]]]
+                   [:where [:where-sub/where [[:where/triple
+                                               [:triple/vec [[:ax/var ?x]
+                                                             [:ax/var ?y]
+                                                             [:ax/var ?z]]]]]]]]]
                 format-ast))))
   (testing "Formatting ASK queries"
     (is (= (cstr/join "\n" ["ASK"
@@ -98,9 +103,10 @@
                   [[:ask []]
                    [:from-named [[:ax/iri "<http://example.org/my-graph/>"]
                                  [:ax/iri "<http://example.org/my-graph-2/>"]]]
-                   [:where [:where-sub/where [[:triple/vec [[:ax/var ?x]
-                                                            [:ax/var ?y]
-                                                            [:ax/var ?z]]]]]]]]
+                   [:where [:where-sub/where [[:where/triple
+                                               [:triple/vec [[:ax/var ?x]
+                                                             [:ax/var ?y]
+                                                             [:ax/var ?z]]]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["ASK"
                             "WHERE {"
@@ -108,7 +114,8 @@
                             "}"])
            (->> '[:query/ask
                   [[:ask []]
-                   [:where [:where-sub/where [[:triple/vec [[:ax/var ?x]
-                                                            [:ax/var ?y]
-                                                            [:ax/var ?z]]]]]]]]
+                   [:where [:where-sub/where [[:where/triple
+                                               [:triple/vec [[:ax/var ?x]
+                                                             [:ax/var ?y]
+                                                             [:ax/var ?z]]]]]]]]]
                 format-ast)))))

--- a/src/test/com/yetanalytics/flint/format/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/triple_test.cljc
@@ -17,19 +17,19 @@
               [:triple/spo [[[:ax/iri "<http://example.org/supercalifragilisticexpialidocious>"]
                              [:triple/po
                               [[[:ax/var ?p1]
-                                [:triple/o [[:triple/object [:ax/var ?o1]]
-                                            [:triple/object [:ax/var ?o2]]]]]
+                                [:triple/o [[:ax/var ?o1]
+                                            [:ax/var ?o2]]]]
                                [[:ax/var ?p2]
-                                [:triple/o [[:triple/object [:ax/var ?o1]]
-                                            [:triple/object [:ax/var ?o2]]]]]]]]
+                                [:triple/o [[:ax/var ?o1]
+                                            [:ax/var ?o2]]]]]]]
                             [[:ax/var ?s2]
                              [:triple/po
                               [[[:ax/var ?p1]
-                                [:triple/o [[:triple/object [:ax/var ?o1]]
-                                            [:triple/object [:ax/var ?o2]]]]]
+                                [:triple/o [[:ax/var ?o1]
+                                            [:ax/var ?o2]]]]
                                [[:ax/var ?p2]
-                                [:triple/o [[:triple/object [:ax/var ?o1]]
-                                            [:triple/object [:ax/var ?o2]]]]]]]]]]]
+                                [:triple/o [[:ax/var ?o1]
+                                            [:ax/var ?o2]]]]]]]]]]
             {:pretty? true})))
     (is (= "?s ?p ?o ."
            (f/format-ast

--- a/src/test/com/yetanalytics/flint/format/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/triple_test.cljc
@@ -34,4 +34,74 @@
     (is (= "?s ?p ?o ."
            (f/format-ast
             '[:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
-            {:pretty? true})))))
+            {:pretty? true})))
+    (is (= "( 1 2 ) :p \"w\" ."
+           (f/format-ast
+            '[:triple.vec/spo
+              [[:triple/list [[:ax/literal 1] [:ax/literal 2]]]
+               [:ax/prefix-iri :p]
+               [:ax/literal "w"]]]
+            {:pretty? true})))
+    (is (= "( ?x ?y ) ."
+           (f/format-ast
+            '[:triple.vec/s
+              [[:triple/list [[:ax/var ?x] [:ax/var ?y]]]]]
+            {:pretty? true})))
+    (is (= "( ?x ?y ) ."
+           (f/format-ast
+            '[:triple.nform/s
+              [[[:triple/list [[:ax/var ?x] [:ax/var ?y]]] []]]]
+            {:pretty? true})))
+    (is (= "\"v\" :p ( 1 2 ( 3 ) ) ."
+           (f/format-ast
+            '[:triple.vec/spo
+              [[:ax/literal "v"]
+               [:ax/prefix-iri :p]
+               [:triple/list [[:ax/literal 1]
+                              [:ax/literal 2]
+                              [:triple/list [[:ax/literal 3]]]]]]]
+            {:pretty? true})))
+    (is (= "[ foaf:name ?name ;\n  foaf:mbox <mailto:foo@example.com> ] :q \"w\" ."
+           (f/format-ast
+            '[:triple.vec/spo
+              [[:triple/bnodes [[[:ax/prefix-iri :foaf/name]
+                                 [:ax/var ?name]]
+                                [[:ax/prefix-iri :foaf/mbox]
+                                 [:ax/iri "<mailto:foo@example.com>"]]]]
+               [:ax/prefix-iri :q]
+               [:ax/literal "w"]]]
+            {:pretty? true})))
+    (is (= "[ foaf:name ?name ; foaf:mbox <mailto:foo@example.com> ] :q \"w\" ."
+           (f/format-ast
+            '[:triple.vec/spo
+              [[:triple/bnodes [[[:ax/prefix-iri :foaf/name]
+                                 [:ax/var ?name]]
+                                [[:ax/prefix-iri :foaf/mbox]
+                                 [:ax/iri "<mailto:foo@example.com>"]]]]
+               [:ax/prefix-iri :q]
+               [:ax/literal "w"]]]
+            {:pretty? false})))
+    (is (= "[ foaf:name ?name ; foaf:mbox <mailto:foo@example.com> ] ."
+           (f/format-ast
+            '[:triple.vec/s
+              [[:triple/bnodes [[[:ax/prefix-iri :foaf/name]
+                                 [:ax/var ?name]]
+                                [[:ax/prefix-iri :foaf/mbox]
+                                 [:ax/iri "<mailto:foo@example.com>"]]]]]]
+            {:pretty? false})))
+    (is (= "[ foo:bar [ foaf:mbox <mailto:foo@example.com> ] ] ."
+           (f/format-ast
+            '[:triple.vec/s
+              [[:triple/bnodes [[[:ax/prefix-iri :foo/bar]
+                                 [:triple/bnodes
+                                  [[[:ax/prefix-iri :foaf/mbox]
+                                    [:ax/iri "<mailto:foo@example.com>"]]]]]]]]]
+            {:pretty? true})))
+    (is (= "[ foo:bar [ foaf:mbox <mailto:foo@example.com> ] ] ."
+           (f/format-ast
+            '[:triple.vec/s
+              [[:triple/bnodes [[[:ax/prefix-iri :foo/bar]
+                                 [:triple/bnodes
+                                  [[[:ax/prefix-iri :foaf/mbox]
+                                    [:ax/iri "<mailto:foo@example.com>"]]]]]]]]]
+            {:pretty? false})))))

--- a/src/test/com/yetanalytics/flint/format/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/triple_test.cljc
@@ -17,15 +17,19 @@
               [:triple/spo [[[:ax/iri "<http://example.org/supercalifragilisticexpialidocious>"]
                              [:triple/po
                               [[[:ax/var ?p1]
-                                [:triple/o [[:ax/var ?o1] [:ax/var ?o2]]]]
+                                [:triple/o [[:triple/object [:ax/var ?o1]]
+                                            [:triple/object [:ax/var ?o2]]]]]
                                [[:ax/var ?p2]
-                                [:triple/o [[:ax/var ?o1] [:ax/var ?o2]]]]]]]
+                                [:triple/o [[:triple/object [:ax/var ?o1]]
+                                            [:triple/object [:ax/var ?o2]]]]]]]]
                             [[:ax/var ?s2]
                              [:triple/po
                               [[[:ax/var ?p1]
-                                [:triple/o [[:ax/var ?o1] [:ax/var ?o2]]]]
+                                [:triple/o [[:triple/object [:ax/var ?o1]]
+                                            [:triple/object [:ax/var ?o2]]]]]
                                [[:ax/var ?p2]
-                                [:triple/o [[:ax/var ?o1] [:ax/var ?o2]]]]]]]]]]
+                                [:triple/o [[:triple/object [:ax/var ?o1]]
+                                            [:triple/object [:ax/var ?o2]]]]]]]]]]]
             {:pretty? true})))
     (is (= "?s ?p ?o ."
            (f/format-ast

--- a/src/test/com/yetanalytics/flint/format/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/triple_test.cljc
@@ -33,5 +33,5 @@
             {:pretty? true})))
     (is (= "?s ?p ?o ."
            (f/format-ast
-            '[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
+            '[:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
             {:pretty? true})))))

--- a/src/test/com/yetanalytics/flint/format/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/triple_test.cljc
@@ -61,6 +61,13 @@
                               [:ax/literal 2]
                               [:triple/list [[:ax/literal 3]]]]]]]
             {:pretty? true})))
+    (is (= "\"v\" :p () ."
+           (f/format-ast
+            '[:triple.vec/spo
+              [[:ax/literal "v"]
+               [:ax/prefix-iri :p]
+               [:triple/list []]]]
+            {:pretty? true})))
     (is (= "[ foaf:name ?name ;\n  foaf:mbox <mailto:foo@example.com> ] :q \"w\" ."
            (f/format-ast
             '[:triple.vec/spo

--- a/src/test/com/yetanalytics/flint/format/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/triple_test.cljc
@@ -13,23 +13,23 @@
              "?s2 ?p1 ?o1 , ?o2 ;"
              "    ?p2 ?o1 , ?o2 ."])
            (f/format-ast
-            '[:triple/nform
-              [:triple/spo [[[:ax/iri "<http://example.org/supercalifragilisticexpialidocious>"]
-                             [:triple/po
-                              [[[:ax/var ?p1]
-                                [:triple/o [[:ax/var ?o1]
-                                            [:ax/var ?o2]]]]
-                               [[:ax/var ?p2]
-                                [:triple/o [[:ax/var ?o1]
-                                            [:ax/var ?o2]]]]]]]
-                            [[:ax/var ?s2]
-                             [:triple/po
-                              [[[:ax/var ?p1]
-                                [:triple/o [[:ax/var ?o1]
-                                            [:ax/var ?o2]]]]
-                               [[:ax/var ?p2]
-                                [:triple/o [[:ax/var ?o1]
-                                            [:ax/var ?o2]]]]]]]]]]
+            '[:triple.nform/spo
+              [[[:ax/iri "<http://example.org/supercalifragilisticexpialidocious>"]
+                [:triple.nform/po
+                 [[[:ax/var ?p1]
+                   [:triple.nform/o [[:ax/var ?o1]
+                                     [:ax/var ?o2]]]]
+                  [[:ax/var ?p2]
+                   [:triple.nform/o [[:ax/var ?o1]
+                                     [:ax/var ?o2]]]]]]]
+               [[:ax/var ?s2]
+                [:triple.nform/po
+                 [[[:ax/var ?p1]
+                   [:triple.nform/o [[:ax/var ?o1]
+                                     [:ax/var ?o2]]]]
+                  [[:ax/var ?p2]
+                   [:triple.nform/o [[:ax/var ?o1]
+                                     [:ax/var ?o2]]]]]]]]]
             {:pretty? true})))
     (is (= "?s ?p ?o ."
            (f/format-ast

--- a/src/test/com/yetanalytics/flint/format/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/triple_test.cljc
@@ -49,8 +49,9 @@
             {:pretty? true})))
     (is (= "( ?x ?y ) ."
            (f/format-ast
-            '[:triple.nform/s
-              [[[:triple/list [[:ax/var ?x] [:ax/var ?y]]] []]]]
+            '[:triple.nform/spo
+              [[[:triple/list [[:ax/var ?x] [:ax/var ?y]]]
+                [:triple.nform/po-empty []]]]]
             {:pretty? true})))
     (is (= "\"v\" :p ( 1 2 ( 3 ) ) ."
            (f/format-ast

--- a/src/test/com/yetanalytics/flint/format/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/triple_test.cljc
@@ -104,4 +104,11 @@
                                  [:triple/bnodes
                                   [[[:ax/prefix-iri :foaf/mbox]
                                     [:ax/iri "<mailto:foo@example.com>"]]]]]]]]]
+            {:pretty? false})))
+    (is (= "[] ?p ?o ."
+           (f/format-ast
+            '[:triple.vec/spo
+              [[:triple/bnodes []]
+               [:ax/var ?p]
+               [:ax/var ?o]]]
             {:pretty? false})))))

--- a/src/test/com/yetanalytics/flint/format/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/update_test.cljc
@@ -25,9 +25,9 @@
                             "}"])
            (->> '[:update/delete-data
                   [[:delete-data
-                    [[:triple/quads
+                    [[:triple.quad/gspo
                       [[:ax/iri "<http://example.org>"]
-                       [:triple/quad-triples
+                       [:triple.quad/spo
                         [[:triple.vec/spo [[:ax/prefix-iri :foo/x]
                                            [:ax/prefix-iri :dc/title]
                                            [:ax/literal "Title"]]]]]]]]]]]
@@ -63,9 +63,9 @@
                         [:triple.nform/po
                          [[[:ax/var ?p]
                            [:triple.nform/o [[:ax/var ?o]]]]]]]]]
-                     [:triple/quads
+                     [:triple.quad/gspo
                       [[:ax/iri "<http://example.org>"]
-                       [:triple/quad-triples
+                       [:triple.quad/spo
                         [[:triple.vec/spo [[:ax/var ?q] [:ax/var ?r] [:ax/var ?s]]]]]]]]]]]
                 format-ast))))
   (testing "Formatting DELETE...INSERT clauses"

--- a/src/test/com/yetanalytics/flint/format/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/update_test.cljc
@@ -81,7 +81,8 @@
                     [:update/named-iri [:named [:ax/iri "<http://example.org/2>"]]]]
                    [:where
                     [:where-sub/where
-                     [[:triple/vec [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]]]]
+                     [[:where/triple
+                       [:triple/vec [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["WITH <http://example.org>"
                             "DELETE {"
@@ -101,14 +102,15 @@
                    [:insert [[:triple/vec [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]
                    [:using [:update/iri [:ax/iri "<http://example.org/2>"]]]
                    [:where [:where-sub/where
-                            [[:triple/nform
-                              [:triple/spo
-                               [[[:ax/var ?x]
-                                 [:triple/po [[[:ax/var ?y]
-                                               [:triple/o [[:triple/object [:ax/var ?z]]]]]]]]
-                                [[:ax/var ?a]
-                                 [:triple/po [[[:ax/var ?b]
-                                               [:triple/o [[:triple/object [:ax/var ?c]]]]]]]]]]]]]]]]
+                            [[:where/triple
+                              [:triple/nform
+                               [:triple/spo
+                                [[[:ax/var ?x]
+                                  [:triple/po [[[:ax/var ?y]
+                                                [:triple/o [[:triple/object [:ax/var ?z]]]]]]]]
+                                 [[:ax/var ?a]
+                                  [:triple/po [[[:ax/var ?b]
+                                                [:triple/o [[:triple/object [:ax/var ?c]]]]]]]]]]]]]]]]]
                 format-ast))))
   (testing "Formatting graph management updates"
     (testing "- LOAD"

--- a/src/test/com/yetanalytics/flint/format/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/update_test.cljc
@@ -13,9 +13,9 @@
                             "    foo:x dc:title \"Title\" ."
                             "}"])
            (->> '[:update/insert-data
-                  [[:insert-data [[:triple/vec [[:ax/prefix-iri :foo/x]
-                                                [:ax/prefix-iri :dc/title]
-                                                [:ax/literal "Title"]]]]]]]
+                  [[:insert-data [[:triple.vec/spo [[:ax/prefix-iri :foo/x]
+                                                    [:ax/prefix-iri :dc/title]
+                                                    [:ax/literal "Title"]]]]]]]
                 format-ast))))
   (testing "Formatting DELETE DATA clauses"
     (is (= (cstr/join "\n" ["DELETE DATA {"
@@ -28,9 +28,9 @@
                     [[:triple/quads
                       [[:ax/iri "<http://example.org>"]
                        [:triple/quad-triples
-                        [[:triple/vec [[:ax/prefix-iri :foo/x]
-                                       [:ax/prefix-iri :dc/title]
-                                       [:ax/literal "Title"]]]]]]]]]]]
+                        [[:triple.vec/spo [[:ax/prefix-iri :foo/x]
+                                           [:ax/prefix-iri :dc/title]
+                                           [:ax/literal "Title"]]]]]]]]]]]
                 format-ast))))
   (testing "Formatting DELETE WHERE clauses"
     (is (= (cstr/join "\n" ["DELETE WHERE {"
@@ -39,8 +39,8 @@
                             "}"])
            (->> '[:update/delete-where
                   [[:delete-where
-                    [[:triple/vec [[:ax/var ?x] [:ax/var ?y] [:ax/var ?z]]]
-                     [:triple/vec [[:ax/var ?i] [:ax/var ?j] [:ax/var ?k]]]]]]]
+                    [[:triple.vec/spo [[:ax/var ?x] [:ax/var ?y] [:ax/var ?z]]]
+                     [:triple.vec/spo [[:ax/var ?i] [:ax/var ?j] [:ax/var ?k]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["DELETE WHERE {"
                             "    ?x ?y ?z ."
@@ -52,7 +52,7 @@
                             "}"])
            (->> '[:update/delete-where
                   [[:delete-where
-                    [[:triple/vec
+                    [[:triple.vec/spo
                       [[:ax/var ?x] [:ax/var ?y] [:ax/var ?z]]]
                      [:triple.nform/spo
                       [[[:ax/var ?i]
@@ -66,7 +66,7 @@
                      [:triple/quads
                       [[:ax/iri "<http://example.org>"]
                        [:triple/quad-triples
-                        [[:triple/vec [[:ax/var ?q] [:ax/var ?r] [:ax/var ?s]]]]]]]]]]]
+                        [[:triple.vec/spo [[:ax/var ?q] [:ax/var ?r] [:ax/var ?s]]]]]]]]]]]
                 format-ast))))
   (testing "Formatting DELETE...INSERT clauses"
     (is (= (cstr/join "\n" ["INSERT {"
@@ -78,13 +78,13 @@
                             "}"])
            (->> '[:update/modify
                   [[:insert
-                    [[:triple/vec [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]
+                    [[:triple.vec/spo [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]
                    [:using
                     [:update/named-iri [:named [:ax/iri "<http://example.org/2>"]]]]
                    [:where
                     [:where-sub/where
                      [[:where/triple
-                       [:triple/vec [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]]]]]
+                       [:triple.vec/spo [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]]]]]
                 format-ast)))
     (is (= (cstr/join "\n" ["WITH <http://example.org>"
                             "DELETE {"
@@ -100,8 +100,8 @@
                             "}"])
            (->> '[:update/modify
                   [[:with [:ax/iri "<http://example.org>"]]
-                   [:delete [[:triple/vec [[:ax/var ?x] [:ax/var ?y] [:ax/var ?z]]]]]
-                   [:insert [[:triple/vec [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]
+                   [:delete [[:triple.vec/spo [[:ax/var ?x] [:ax/var ?y] [:ax/var ?z]]]]]
+                   [:insert [[:triple.vec/spo [[:ax/var ?a] [:ax/var ?b] [:ax/var ?c]]]]]
                    [:using [:update/iri [:ax/iri "<http://example.org/2>"]]]
                    [:where [:where-sub/where
                             [[:where/triple

--- a/src/test/com/yetanalytics/flint/format/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/update_test.cljc
@@ -57,10 +57,10 @@
                      [:triple/nform
                       [:triple/spo [[[:ax/var ?i]
                                      [:triple/po [[[:ax/var ?j]
-                                                   [:triple/o [[:ax/var ?k]]]]]]]
+                                                   [:triple/o [[:triple/object [:ax/var ?k]]]]]]]]
                                     [[:ax/var ?s]
                                      [:triple/po [[[:ax/var ?p]
-                                                   [:triple/o [[:ax/var ?o]]]]]]]]]]
+                                                   [:triple/o [[:triple/object [:ax/var ?o]]]]]]]]]]]
                      [:triple/quads
                       [[:ax/iri "<http://example.org>"]
                        [:triple/quad-triples
@@ -105,10 +105,10 @@
                               [:triple/spo
                                [[[:ax/var ?x]
                                  [:triple/po [[[:ax/var ?y]
-                                               [:triple/o [[:ax/var ?z]]]]]]]
+                                               [:triple/o [[:triple/object [:ax/var ?z]]]]]]]]
                                 [[:ax/var ?a]
                                  [:triple/po [[[:ax/var ?b]
-                                               [:triple/o [[:ax/var ?c]]]]]]]]]]]]]]]
+                                               [:triple/o [[:triple/object [:ax/var ?c]]]]]]]]]]]]]]]]
                 format-ast))))
   (testing "Formatting graph management updates"
     (testing "- LOAD"

--- a/src/test/com/yetanalytics/flint/format/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/update_test.cljc
@@ -54,13 +54,15 @@
                   [[:delete-where
                     [[:triple/vec
                       [[:ax/var ?x] [:ax/var ?y] [:ax/var ?z]]]
-                     [:triple/nform
-                      [:triple/spo [[[:ax/var ?i]
-                                     [:triple/po [[[:ax/var ?j]
-                                                   [:triple/o [[:triple/object [:ax/var ?k]]]]]]]]
-                                    [[:ax/var ?s]
-                                     [:triple/po [[[:ax/var ?p]
-                                                   [:triple/o [[:triple/object [:ax/var ?o]]]]]]]]]]]
+                     [:triple.nform/spo
+                      [[[:ax/var ?i]
+                        [:triple.nform/po
+                         [[[:ax/var ?j]
+                           [:triple.nform/o [[:ax/var ?k]]]]]]]
+                       [[:ax/var ?s]
+                        [:triple.nform/po
+                         [[[:ax/var ?p]
+                           [:triple.nform/o [[:ax/var ?o]]]]]]]]]
                      [:triple/quads
                       [[:ax/iri "<http://example.org>"]
                        [:triple/quad-triples
@@ -103,14 +105,15 @@
                    [:using [:update/iri [:ax/iri "<http://example.org/2>"]]]
                    [:where [:where-sub/where
                             [[:where/triple
-                              [:triple/nform
-                               [:triple/spo
-                                [[[:ax/var ?x]
-                                  [:triple/po [[[:ax/var ?y]
-                                                [:triple/o [[:triple/object [:ax/var ?z]]]]]]]]
-                                 [[:ax/var ?a]
-                                  [:triple/po [[[:ax/var ?b]
-                                                [:triple/o [[:triple/object [:ax/var ?c]]]]]]]]]]]]]]]]]
+                              [:triple.nform/spo
+                               [[[:ax/var ?x]
+                                 [:triple.nform/po
+                                  [[[:ax/var ?y]
+                                    [:triple.nform/o [[:ax/var ?z]]]]]]]
+                                [[:ax/var ?a]
+                                 [:triple.nform/po
+                                  [[[:ax/var ?b]
+                                    [:triple.nform/o [[:ax/var ?c]]]]]]]]]]]]]]]
                 format-ast))))
   (testing "Formatting graph management updates"
     (testing "- LOAD"

--- a/src/test/com/yetanalytics/flint/format/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/where_test.cljc
@@ -55,11 +55,12 @@
                    [:triple/vec
                     [[:ax/var ?s1] [:ax/var ?p1] [:ax/var ?o1]]]]
                   [:where/triple
-                   [:triple/nform
-                    [:triple/spo [[[:ax/var ?s2]
-                                   [:triple/po [[[:ax/var ?p2]
-                                                 [:triple/o [[:triple/object [:ax/var ?o2a]]
-                                                             [:triple/object [:ax/var ?o2b]]]]]]]]]]]]
+                   [:triple.nform/spo
+                    [[[:ax/var ?s2]
+                      [:triple.nform/po
+                       [[[:ax/var ?p2]
+                         [:triple.nform/o [[:ax/var ?o2a]
+                                           [:ax/var ?o2b]]]]]]]]]]
                   [:where/special
                    [:where/recurse
                     [:where-sub/where

--- a/src/test/com/yetanalytics/flint/format/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/where_test.cljc
@@ -11,8 +11,8 @@
                             "    ?s ?p ?o ."
                             "}"])
            (-> '[:where-sub/where
-                 [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]
-                  [:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]
+                 [[:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]
+                  [:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]
                (f/format-ast {:pretty? true}))))
     (is (= (cstr/join "\n" ["{"
                             "    ?s1 ?p1 ?o1 ."
@@ -52,7 +52,7 @@
                             "}"])
            (-> '[:where-sub/where
                  [[:where/triple
-                   [:triple/vec
+                   [:triple.vec/spo
                     [[:ax/var ?s1] [:ax/var ?p1] [:ax/var ?o1]]]]
                   [:where/triple
                    [:triple.nform/spo
@@ -64,37 +64,37 @@
                   [:where/special
                    [:where/recurse
                     [:where-sub/where
-                     [[:where/triple [:triple/vec [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]]]
+                     [[:where/triple [:triple.vec/spo [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]]]
                   [:where/special
                    [:where/union
                     [[:where-sub/where
-                      [[:where/triple [:triple/vec
+                      [[:where/triple [:triple.vec/spo
                                        [[:ax/var ?s4] [:ax/var ?p4] [:ax/var ?o4]]]]]]
                      [:where-sub/where
-                      [[:where/triple [:triple/vec [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]]
+                      [[:where/triple [:triple.vec/spo [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]]
                   [:where/special
                    [:where/optional
                     [:where-sub/where
-                     [[:where/triple [:triple/vec [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]]]
+                     [[:where/triple [:triple.vec/spo [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]]]
                   [:where/special
                    [:where/minus
                     [:where-sub/where
-                     [[:where/triple [:triple/vec [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]]]
+                     [[:where/triple [:triple.vec/spo [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]]]
                   [:where/special
                    [:where/graph
                     [[:ax/prefix-iri :ns/my-graph]
                      [:where-sub/where
-                      [[:where/triple [:triple/vec [[:ax/var ?s8] [:ax/var ?p8] [:ax/var ?o8]]]]]]]]]
+                      [[:where/triple [:triple.vec/spo [[:ax/var ?s8] [:ax/var ?p8] [:ax/var ?o8]]]]]]]]]
                   [:where/special
                    [:where/service
                     [[:ax/prefix-iri :ns/my-uri]
                      [:where-sub/where
-                      [[:where/triple [:triple/vec [[:ax/var ?s9] [:ax/var ?p9] [:ax/var ?o9]]]]]]]]]
+                      [[:where/triple [:triple.vec/spo [[:ax/var ?s9] [:ax/var ?p9] [:ax/var ?o9]]]]]]]]]
                   [:where/special
                    [:where/service-silent
                     [[:ax/prefix-iri :ns/my-uri]
                      [:where-sub/where
-                      [[:where/triple [:triple/vec [[:ax/var ?s10] [:ax/var ?p10] [:ax/var ?o10]]]]]]]]]
+                      [[:where/triple [:triple.vec/spo [[:ax/var ?s10] [:ax/var ?p10] [:ax/var ?o10]]]]]]]]]
                   [:where/special
                    [:where/bind
                     [:expr/as-var

--- a/src/test/com/yetanalytics/flint/format/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/where_test.cljc
@@ -56,8 +56,8 @@
                   [:triple/nform
                    [:triple/spo [[[:ax/var ?s2]
                                   [:triple/po [[[:ax/var ?p2]
-                                                [:triple/o [[:ax/var ?o2a]
-                                                            [:ax/var ?o2b]]]]]]]]]]
+                                                [:triple/o [[:triple/object [:ax/var ?o2a]]
+                                                            [:triple/object [:ax/var ?o2b]]]]]]]]]]]
                   [:where/special
                    [:where/recurse
                     [:where-sub/where

--- a/src/test/com/yetanalytics/flint/format/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/format/where_test.cljc
@@ -11,8 +11,8 @@
                             "    ?s ?p ?o ."
                             "}"])
            (-> '[:where-sub/where
-                 [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
-                  [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]
+                 [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]
+                  [:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]
                (f/format-ast {:pretty? true}))))
     (is (= (cstr/join "\n" ["{"
                             "    ?s1 ?p1 ?o1 ."
@@ -51,47 +51,49 @@
                             "    }"
                             "}"])
            (-> '[:where-sub/where
-                 [[:triple/vec
-                   [[:ax/var ?s1] [:ax/var ?p1] [:ax/var ?o1]]]
-                  [:triple/nform
-                   [:triple/spo [[[:ax/var ?s2]
-                                  [:triple/po [[[:ax/var ?p2]
-                                                [:triple/o [[:triple/object [:ax/var ?o2a]]
-                                                            [:triple/object [:ax/var ?o2b]]]]]]]]]]]
+                 [[:where/triple
+                   [:triple/vec
+                    [[:ax/var ?s1] [:ax/var ?p1] [:ax/var ?o1]]]]
+                  [:where/triple
+                   [:triple/nform
+                    [:triple/spo [[[:ax/var ?s2]
+                                   [:triple/po [[[:ax/var ?p2]
+                                                 [:triple/o [[:triple/object [:ax/var ?o2a]]
+                                                             [:triple/object [:ax/var ?o2b]]]]]]]]]]]]
                   [:where/special
                    [:where/recurse
                     [:where-sub/where
-                     [[:triple/vec [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]]
+                     [[:where/triple [:triple/vec [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]]]
                   [:where/special
                    [:where/union
                     [[:where-sub/where
-                      [[:triple/vec
-                        [[:ax/var ?s4] [:ax/var ?p4] [:ax/var ?o4]]]]]
+                      [[:where/triple [:triple/vec
+                                       [[:ax/var ?s4] [:ax/var ?p4] [:ax/var ?o4]]]]]]
                      [:where-sub/where
-                      [[:triple/vec [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]
+                      [[:where/triple [:triple/vec [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]]
                   [:where/special
                    [:where/optional
                     [:where-sub/where
-                     [[:triple/vec [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]]
+                     [[:where/triple [:triple/vec [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]]]
                   [:where/special
                    [:where/minus
                     [:where-sub/where
-                     [[:triple/vec [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]]
+                     [[:where/triple [:triple/vec [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]]]
                   [:where/special
                    [:where/graph
                     [[:ax/prefix-iri :ns/my-graph]
                      [:where-sub/where
-                      [[:triple/vec [[:ax/var ?s8] [:ax/var ?p8] [:ax/var ?o8]]]]]]]]
+                      [[:where/triple [:triple/vec [[:ax/var ?s8] [:ax/var ?p8] [:ax/var ?o8]]]]]]]]]
                   [:where/special
                    [:where/service
                     [[:ax/prefix-iri :ns/my-uri]
                      [:where-sub/where
-                      [[:triple/vec [[:ax/var ?s9] [:ax/var ?p9] [:ax/var ?o9]]]]]]]]
+                      [[:where/triple [:triple/vec [[:ax/var ?s9] [:ax/var ?p9] [:ax/var ?o9]]]]]]]]]
                   [:where/special
                    [:where/service-silent
                     [[:ax/prefix-iri :ns/my-uri]
                      [:where-sub/where
-                      [[:triple/vec [[:ax/var ?s10] [:ax/var ?p10] [:ax/var ?o10]]]]]]]]
+                      [[:where/triple [:triple/vec [[:ax/var ?s10] [:ax/var ?p10] [:ax/var ?o10]]]]]]]]]
                   [:where/special
                    [:where/bind
                     [:expr/as-var

--- a/src/test/com/yetanalytics/flint/spec/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/expr_test.cljc
@@ -42,9 +42,9 @@
     (is (= [:expr/branch [[:expr/op 'exists]
                           [:expr/args [[:where-sub/where
                                         [[:where/triple
-                                          [:triple/vec '[[:ax/var ?s]
-                                                         [:ax/var ?p]
-                                                         [:ax/var ?o]]]]]]]]]]
+                                          [:triple.vec/spo '[[:ax/var ?s]
+                                                             [:ax/var ?p]
+                                                             [:ax/var ?o]]]]]]]]]]
            (s/conform ::es/expr '(exists [[?s ?p ?o]]))))
     (is (= [:expr/branch [[:expr/op 'contains]
                           [:expr/args [[:expr/terminal [:ax/literal "foo"]]

--- a/src/test/com/yetanalytics/flint/spec/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/expr_test.cljc
@@ -41,9 +41,10 @@
     ;; (We can't `require` it due to circular dependencies.)
     (is (= [:expr/branch [[:expr/op 'exists]
                           [:expr/args [[:where-sub/where
-                                        [[:triple/vec '[[:ax/var ?s]
-                                                        [:ax/var ?p]
-                                                        [:ax/var ?o]]]]]]]]]
+                                        [[:where/triple
+                                          [:triple/vec '[[:ax/var ?s]
+                                                         [:ax/var ?p]
+                                                         [:ax/var ?o]]]]]]]]]]
            (s/conform ::es/expr '(exists [[?s ?p ?o]]))))
     (is (= [:expr/branch [[:expr/op 'contains]
                           [:expr/args [[:expr/terminal [:ax/literal "foo"]]

--- a/src/test/com/yetanalytics/flint/spec/query_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/query_test.cljc
@@ -19,9 +19,9 @@
               [:select [:select/var-or-exprs [[:ax/var ?x]]]]
               [:from [:ax/iri "<http://example.org/my-graph/>"]]
               [:where [:where-sub/where [[:where/triple
-                                          [:triple/vec [[:ax/var ?x]
-                                                        [:ax/var ?y]
-                                                        [:ax/var ?z]]]]]]]
+                                          [:triple.vec/spo [[:ax/var ?x]
+                                                            [:ax/var ?y]
+                                                            [:ax/var ?z]]]]]]]
               [:order-by [[:mod/asc-desc
                            [[:mod/op asc]
                             [:mod/asc-desc-expr [:expr/terminal [:ax/var ?y]]]]]]]

--- a/src/test/com/yetanalytics/flint/spec/query_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/query_test.cljc
@@ -18,9 +18,10 @@
              [[:prefixes [[:prologue/prefix [[:ax/prefix :foo] [:ax/iri "<http://example.org/foo/>"]]]]]
               [:select [:select/var-or-exprs [[:ax/var ?x]]]]
               [:from [:ax/iri "<http://example.org/my-graph/>"]]
-              [:where [:where-sub/where [[:triple/vec [[:ax/var ?x]
-                                                       [:ax/var ?y]
-                                                       [:ax/var ?z]]]]]]
+              [:where [:where-sub/where [[:where/triple
+                                          [:triple/vec [[:ax/var ?x]
+                                                        [:ax/var ?y]
+                                                        [:ax/var ?z]]]]]]]
               [:order-by [[:mod/asc-desc
                            [[:mod/op asc]
                             [:mod/asc-desc-expr [:expr/terminal [:ax/var ?y]]]]]]]

--- a/src/test/com/yetanalytics/flint/spec/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/triple_test.cljc
@@ -5,21 +5,26 @@
 
 (deftest conform-triple-test
   (testing "Conforming triples"
-    (is (= '[:triple/spo [[[:ax/var ?s]
-                    [:triple/po [[[:ax/var ?p]
-                           [:triple/o [[:ax/var ?o]]]]]]]]]
+    (is (= '[:triple/spo
+             [[[:ax/var ?s]
+               [:triple/po [[[:ax/var ?p]
+                             [:triple/o [[:triple/object [:ax/var ?o]]]]]]]]]]
            (s/conform ts/normal-form-spec '{?s {?p #{?o}}})))
     (is (= '[:triple/spo
              [[[:ax/var ?s1]
                [:triple/po [[[:ax/var ?p1]
-                             [:triple/o [[:ax/var ?o1] [:ax/var ?o2]]]]
+                             [:triple/o [[:triple/object [:ax/var ?o1]]
+                                         [:triple/object [:ax/var ?o2]]]]]
                             [[:ax/var ?p2]
-                             [:triple/o [[:ax/var ?o1] [:ax/var ?o2]]]]]]]
+                             [:triple/o [[:triple/object [:ax/var ?o1]]
+                                         [:triple/object [:ax/var ?o2]]]]]]]]
               [[:ax/var ?s2]
                [:triple/po [[[:ax/var ?p1]
-                             [:triple/o [[:ax/var ?o1] [:ax/var ?o2]]]]
+                             [:triple/o [[:triple/object [:ax/var ?o1]]
+                                         [:triple/object [:ax/var ?o2]]]]]
                             [[:ax/var ?p2]
-                             [:triple/o [[:ax/var ?o1] [:ax/var ?o2]]]]]]]]]
+                             [:triple/o [[:triple/object [:ax/var ?o1]]
+                                         [:triple/object [:ax/var ?o2]]]]]]]]]]
            (s/conform ts/normal-form-spec '{?s1 {?p1 #{?o1 ?o2}
                                                  ?p2 #{?o1 ?o2}}
                                             ?s2 {?p1 #{?o1 ?o2}
@@ -35,7 +40,7 @@
                                     [:path/paths
                                      [[:path/terminal [:ax/prefix-iri :x/one]]
                                       [:path/terminal [:ax/prefix-iri :x/two]]]]]]]
-                    [:triple/o [[:ax/var ?o]]]]]]]]]
+                    [:triple/o [[:triple/object [:ax/var ?o]]]]]]]]]]
              (s/conform ts/normal-form-spec
                         '{?s {(cat :x/one :x/two) #{?o}}})))
       (is (= '[[:ax/var ?s]

--- a/src/test/com/yetanalytics/flint/spec/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/triple_test.cljc
@@ -178,4 +178,126 @@
                 [:ax/prefix-iri :q]
                 [:ax/literal "w"]]]
              (s/conform ts/triple-spec
-                        '[[:p1 ?x1 :p2 ?x2] :q "w"]))))))
+                        '[[:p1 ?x1 :p2 ?x2] :q "w"])))
+      (testing "and path + var in subject"
+        (is (= '[:triple.vec/spo
+                 [[:triple/bnodes
+                   [[[:triple/path
+                      [:path/branch
+                       [[:path/op cat]
+                        [:path/paths
+                         [[:path/terminal [:ax/prefix-iri :p1]]
+                          [:path/terminal [:ax/prefix-iri :p2]]]]]]]
+                     [:ax/var ?x]]]]
+                  [:ax/prefix-iri :q]
+                  [:ax/literal "w"]]]
+               (s/conform ts/triple-spec
+                          '[[(cat :p1 :p2) ?x] :q "w"])))
+        (is (= '[:triple.nform/spo
+                 [[[:triple/bnodes
+                     [[[:triple/path
+                        [:path/branch
+                         [[:path/op cat]
+                          [:path/paths
+                           [[:path/terminal [:ax/prefix-iri :p1]]
+                            [:path/terminal [:ax/prefix-iri :p2]]]]]]]
+                       [:ax/var ?x]]]]
+                   [:triple.nform/po
+                    [[[:ax/prefix-iri :q]
+                      [:triple.nform/o
+                       [[:ax/literal "w"]]]]]]]]]
+               (s/conform ts/triple-spec
+                          '{[(cat :p1 :p2) ?x] {:q #{"w"}}})))
+        (is (not (s/valid? ts/triple-nopath-spec
+                           '[[(cat :p1 :p2) ?x] :q "w"])))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '[[(cat :p1 :p2) ?x] :q "w"])))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '[[(cat :p1 :p2) ?x] :q "w"])))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '[[(cat :p1 :p2) ?x] :q "w"])))
+        (is (not (s/valid? ts/triple-nopath-spec
+                           '[[(cat :p1 :p2) ?x]])))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '[[(cat :p1 :p2) ?x]])))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '[[(cat :p1 :p2) ?x]])))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '[[(cat :p1 :p2) ?x]])))
+        (is (not (s/valid? ts/triple-nopath-spec
+                           '{[(cat :p1 :p2) ?x] {:q #{"w"}}})))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '{[(cat :p1 :p2) ?x] {:q #{"w"}}})))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '{[(cat :p1 :p2) ?x] {:q #{"w"}}})))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '{[(cat :p1 :p2) ?x] {:q #{"w"}}})))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '[(?x ?y) :q "w"])))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '[(?x ?y) :q "w"])))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '[(?x ?y) :q "w"])))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '{(?x ?y) {:q #{"w"}}})))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '{(?x ?y) {:q #{"w"}}})))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '{(?x ?y) {:q #{"w"}}}))))
+      (testing "and path + var in object"
+        (is (= '[:triple.vec/spo
+                 [[:ax/prefix-iri :x]
+                  [:ax/prefix-iri :q]
+                  [:triple/bnodes
+                   [[[:triple/path
+                      [:path/branch
+                       [[:path/op cat]
+                        [:path/paths
+                         [[:path/terminal [:ax/prefix-iri :r1]]
+                          [:path/terminal [:ax/prefix-iri :r2]]]]]]]
+                     [:ax/literal "v"]]]]]]
+               (s/conform ts/triple-spec
+                          '[:x :q [(cat :r1 :r2) "v"]])))
+        (is (= '[:triple.nform/spo
+                 [[[:ax/prefix-iri :x]
+                   [:triple.nform/po
+                    [[[:ax/prefix-iri :q]
+                      [:triple.nform/o
+                       [[:triple/bnodes
+                         [[[:triple/path
+                            [:path/branch
+                             [[:path/op cat]
+                              [:path/paths
+                               [[:path/terminal [:ax/prefix-iri :r1]]
+                                [:path/terminal [:ax/prefix-iri :r2]]]]]]]
+                           [:ax/literal "v"]]]]]]]]]]]]
+               (s/conform ts/triple-spec
+                          '{:x {:q #{[(cat :r1 :r2) "v"]}}})))
+        (is (not (s/valid? ts/triple-nopath-spec
+                           '[:x :q [(cat :r1 :r2) "v"]])))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '[:x :q [:r ?v]])))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '[:x :q [:r ?v]])))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '[:x :q [:r ?v]])))
+        (is (not (s/valid? ts/triple-nopath-spec
+                           '{:x {:q #{[(cat :r1 :r2) "v"]}}})))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '{:x {:q #{[:r ?v]}}})))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '{:x {:q #{[:r ?v]}}})))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '{:x {:q #{[:r ?v]}}})))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '[:x :q (?w ?v)])))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '[:x :q (?w ?v)])))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '[:x :q (?w ?v)])))
+        (is (not (s/valid? ts/triple-novar-spec
+                           '{:x {:q #{(?w ?v)}}})))
+        (is (not (s/valid? ts/triple-noblank-spec
+                           '{:x {:q #{(?w ?v)}}})))
+        (is (not (s/valid? ts/triple-novar-noblank-spec
+                           '{:x {:q #{(?w ?v)}}})))))))

--- a/src/test/com/yetanalytics/flint/spec/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/triple_test.cljc
@@ -5,58 +5,62 @@
 
 (deftest conform-triple-test
   (testing "Conforming triples"
-    (is (= '[:triple/spo
+    (is (= '[:triple.nform/spo
              [[[:ax/var ?s]
-               [:triple/po [[[:ax/var ?p]
-                             [:triple/o [[:ax/var ?o]]]]]]]]]
-           (s/conform ts/normal-form-spec '{?s {?p #{?o}}})))
-    (is (= '[:triple/spo
+               [:triple.nform/po
+                [[[:ax/var ?p]
+                  [:triple.nform/o [[:ax/var ?o]]]]]]]]]
+           (s/conform ts/triple-spec '{?s {?p #{?o}}})))
+    (is (= '[:triple.nform/spo
              [[[:ax/var ?s1]
-               [:triple/po [[[:ax/var ?p1]
-                             [:triple/o [[:ax/var ?o1]
-                                         [:ax/var ?o2]]]]
-                            [[:ax/var ?p2]
-                             [:triple/o [[:ax/var ?o1]
-                                         [:ax/var ?o2]]]]]]]
+               [:triple.nform/po
+                [[[:ax/var ?p1]
+                  [:triple.nform/o [[:ax/var ?o1]
+                                    [:ax/var ?o2]]]]
+                 [[:ax/var ?p2]
+                  [:triple.nform/o [[:ax/var ?o1]
+                                    [:ax/var ?o2]]]]]]]
               [[:ax/var ?s2]
-               [:triple/po [[[:ax/var ?p1]
-                             [:triple/o [[:ax/var ?o1]
-                                         [:ax/var ?o2]]]]
-                            [[:ax/var ?p2]
-                             [:triple/o [[:ax/var ?o1]
-                                         [:ax/var ?o2]]]]]]]]]
-           (s/conform ts/normal-form-spec '{?s1 {?p1 #{?o1 ?o2}
-                                                 ?p2 #{?o1 ?o2}}
-                                            ?s2 {?p1 #{?o1 ?o2}
-                                                 ?p2 #{?o1 ?o2}}})))
-    (is (= '[[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]
-           (s/conform ts/triple-vec-spec '[?s ?p ?o])))
+               [:triple.nform/po
+                [[[:ax/var ?p1]
+                  [:triple.nform/o [[:ax/var ?o1]
+                              [:ax/var ?o2]]]]
+                 [[:ax/var ?p2]
+                  [:triple.nform/o [[:ax/var ?o1]
+                                    [:ax/var ?o2]]]]]]]]]
+           (s/conform ts/triple-spec '{?s1 {?p1 #{?o1 ?o2}
+                                            ?p2 #{?o1 ?o2}}
+                                       ?s2 {?p1 #{?o1 ?o2}
+                                            ?p2 #{?o1 ?o2}}})))
+    (is (= '[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
+           (s/conform ts/triple-spec '[?s ?p ?o])))
     (testing "with and without paths"
-      (is (= '[:triple/spo
+      (is (= '[:triple.nform/spo
                [[[:ax/var ?s]
-                 [:triple/po
+                 [:triple.nform/po
                   [[[:triple/path
                      [:path/branch [[:path/op cat]
                                     [:path/paths
                                      [[:path/terminal [:ax/prefix-iri :x/one]]
                                       [:path/terminal [:ax/prefix-iri :x/two]]]]]]]
-                    [:triple/o [[:ax/var ?o]]]]]]]]]
-             (s/conform ts/normal-form-spec
+                    [:triple.nform/o [[:ax/var ?o]]]]]]]]]
+             (s/conform ts/triple-spec
                         '{?s {(cat :x/one :x/two) #{?o}}})))
-      (is (= '[[:ax/var ?s]
-               [:triple/path
-                [:path/branch [[:path/op cat]
-                               [:path/paths
-                                [[:path/terminal [:ax/prefix-iri :x/one]]
-                                 [:path/terminal [:ax/prefix-iri :x/two]]]]]]]
-               [:ax/var ?o]]
-             (s/conform ts/triple-vec-spec
+      (is (= '[:triple/vec
+               [[:ax/var ?s]
+                [:triple/path
+                 [:path/branch [[:path/op cat]
+                                [:path/paths
+                                 [[:path/terminal [:ax/prefix-iri :x/one]]
+                                  [:path/terminal [:ax/prefix-iri :x/two]]]]]]]
+                [:ax/var ?o]]]
+             (s/conform ts/triple-spec
                         '[?s (cat :x/one :x/two) ?o])))
-      (is (not (s/valid? ts/normal-form-nopath-spec
+      (is (not (s/valid? ts/triple-nopath-spec
                          '{?s {(cat :x/one :x/two) #{?o}}})))
       (is (->> '{?s {(cat :x/one :x/two) #{?o}}}
-               (s/explain-data ts/normal-form-nopath-spec)
+               (s/explain-data ts/triple-nopath-spec)
                ::s/problems
-               (filter #(-> % :path first (= :triple/spo)))
+               (filter #(-> % :path first (= :triple.nform/spo)))
                (map :val)
                (every? (partial = '(cat :x/one :x/two))))))))

--- a/src/test/com/yetanalytics/flint/spec/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/triple_test.cljc
@@ -61,7 +61,7 @@
       (is (->> '{?s {(cat :x/one :x/two) #{?o}}}
                (s/explain-data ts/triple-nopath-spec)
                ::s/problems
-               (filter #(-> % :path first (= :triple.nform/spo)))
+               (filter #(-> % :path butlast (= [:triple.nform/spo 1 :triple.nform/po 0])))
                (map :val)
                (every? (partial = '(cat :x/one :x/two))))))
     (testing "with list and blank nodes"
@@ -106,11 +106,11 @@
                                [:triple/list [[:ax/literal 2]]]]]]]
              (s/conform ts/triple-spec
                         '[(1 ?x (2))])))
-      (is (= '[:triple.nform/s
+      (is (= '[:triple.nform/spo
                [[[:triple/list [[:ax/literal 1]
                                 [:ax/var ?x]
                                 [:triple/list [[:ax/literal 2]]]]]
-                 []]]]
+                 [:triple.nform/po-empty []]]]]
              (s/conform ts/triple-spec
                         '{(1 ?x (2)) {}})))
       (is (= '[:triple.vec/s

--- a/src/test/com/yetanalytics/flint/spec/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/triple_test.cljc
@@ -32,7 +32,7 @@
                                             ?p2 #{?o1 ?o2}}
                                        ?s2 {?p1 #{?o1 ?o2}
                                             ?p2 #{?o1 ?o2}}})))
-    (is (= '[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
+    (is (= '[:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
            (s/conform ts/triple-spec '[?s ?p ?o])))
     (testing "with and without paths"
       (is (= '[:triple.nform/spo
@@ -46,7 +46,7 @@
                     [:triple.nform/o [[:ax/var ?o]]]]]]]]]
              (s/conform ts/triple-spec
                         '{?s {(cat :x/one :x/two) #{?o}}})))
-      (is (= '[:triple/vec
+      (is (= '[:triple.vec/spo
                [[:ax/var ?s]
                 [:triple/path
                  [:path/branch [[:path/op cat]

--- a/src/test/com/yetanalytics/flint/spec/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/triple_test.cljc
@@ -24,7 +24,7 @@
                [:triple.nform/po
                 [[[:ax/var ?p1]
                   [:triple.nform/o [[:ax/var ?o1]
-                              [:ax/var ?o2]]]]
+                                    [:ax/var ?o2]]]]
                  [[:ax/var ?p2]
                   [:triple.nform/o [[:ax/var ?o1]
                                     [:ax/var ?o2]]]]]]]]]
@@ -63,4 +63,119 @@
                ::s/problems
                (filter #(-> % :path first (= :triple.nform/spo)))
                (map :val)
-               (every? (partial = '(cat :x/one :x/two))))))))
+               (every? (partial = '(cat :x/one :x/two))))))
+    (testing "with list and blank nodes"
+      (is (= '[:triple.vec/spo
+               [[:triple/list [[:ax/literal 1]
+                               [:ax/var ?x]
+                               [:ax/literal 3]
+                               [:ax/literal 4]]]
+                [:ax/prefix-iri :p]
+                [:ax/literal "w"]]]
+             (s/conform ts/triple-spec
+                        '[(1 ?x 3 4) :p "w"])))
+      (is (= '[:triple.vec/spo
+               [[:ax/var ?s]
+                [:ax/var ?p]
+                [:triple/list [[:ax/literal 100] [:ax/literal 200] [:ax/literal 300]]]]]
+             (s/conform ts/triple-spec
+                        '[?s ?p (100 200 300)])))
+      (is (= '[:triple.nform/spo
+               [[[:triple/list [[:ax/literal 1]
+                                [:ax/var ?x]
+                                [:ax/literal 3]
+                                [:ax/literal 4]]]
+                 [:triple.nform/po
+                  [[[:ax/prefix-iri :p]
+                    [:triple.nform/o [[:ax/literal "w"]]]]]]]]]
+             (s/conform ts/triple-spec
+                        '{(1 ?x 3 4) {:p #{"w"}}})))
+      (is (= '[:triple.nform/spo
+               [[[:ax/var ?x]
+                 [:triple.nform/po
+                  [[[:ax/prefix-iri :p]
+                    [:triple.nform/o
+                     [[:triple/list [[:ax/literal 100]
+                                     [:ax/literal 200]
+                                     [:ax/literal 300]]]]]]]]]]]
+             (s/conform ts/triple-spec
+                        '{?x {:p #{(100 200 300)}}})))
+      (is (= '[:triple.vec/s
+               [[:triple/list [[:ax/literal 1]
+                               [:ax/var ?x]
+                               [:triple/list [[:ax/literal 2]]]]]]]
+             (s/conform ts/triple-spec
+                        '[(1 ?x (2))])))
+      (is (= '[:triple.nform/s
+               [[[:triple/list [[:ax/literal 1]
+                                [:ax/var ?x]
+                                [:triple/list [[:ax/literal 2]]]]]
+                 []]]]
+             (s/conform ts/triple-spec
+                        '{(1 ?x (2)) {}})))
+      (is (= '[:triple.vec/s
+               [[:triple/list [[:ax/literal 1]
+                               [:triple/bnodes [[[:ax/prefix-iri :p]
+                                                 [:ax/prefix-iri :q]]]]
+                               [:triple/list [[:ax/literal 2]]]]]]]
+             (s/conform ts/triple-spec
+                        '[(1 [:p :q] (2))])))
+      (is (= '[:triple.vec/spo
+               [[:triple/bnodes [[[:ax/prefix-iri :p]
+                                  [:ax/literal "v"]]]]
+                [:ax/prefix-iri :q]
+                [:ax/literal "w"]]]
+             (s/conform ts/triple-spec
+                        '[[:p "v"] :q "w"])))
+      (is (= '[:triple.vec/spo
+               [[:ax/prefix-iri :x]
+                [:ax/prefix-iri :q]
+                [:triple/bnodes [[[:ax/prefix-iri :p]
+                                  [:ax/literal "v"]]]]]]
+             (s/conform ts/triple-spec
+                        '[:x :q [:p "v"]])))
+      (is (= '[:triple.nform/spo
+               [[[:triple/bnodes
+                  [[[:ax/prefix-iri :p]
+                    [:ax/literal "v"]]]]
+                 [:triple.nform/po
+                  [[[:ax/prefix-iri :q]
+                    [:triple.nform/o [[:ax/literal "w"]]]]]]]]]
+             (s/conform ts/triple-spec
+                        '{[:p "v"] {:q #{"w"}}})))
+      (is (= '[:triple.nform/spo
+               [[[:ax/prefix-iri :x]
+                 [:triple.nform/po
+                  [[[:ax/prefix-iri :q]
+                    [:triple.nform/o
+                     [[:triple/bnodes [[[:ax/prefix-iri :p]
+                                        [:ax/literal "v"]]]]]]]]]]]]
+             (s/conform ts/triple-spec
+                        '{:x {:q #{[:p "v"]}}})))
+      (is (= '[:triple.vec/spo
+               [[:triple/bnodes []]
+                [:ax/prefix-iri :q]
+                [:ax/literal "w"]]]
+             (s/conform ts/triple-spec
+                        '[[] :q "w"])))
+      (is (= '[:triple.vec/spo
+               [[:triple/bnodes
+                 [[[:ax/prefix-iri :p0]
+                   [:triple/bnodes
+                    [[[:ax/prefix-iri :p1]
+                      [:triple/bnodes [[[:ax/prefix-iri :p2]
+                                        [:ax/literal "v"]]]]]]]]]]
+                [:ax/prefix-iri :q]
+                [:ax/literal "w"]]]
+             (s/conform ts/triple-spec
+                        '[[:p0 [:p1 [:p2 "v"]]] :q "w"])))
+      (is (= '[:triple.vec/spo
+               [[:triple/bnodes
+                 [[[:ax/prefix-iri :p1]
+                   [:ax/var ?x1]]
+                  [[:ax/prefix-iri :p2]
+                   [:ax/var ?x2]]]]
+                [:ax/prefix-iri :q]
+                [:ax/literal "w"]]]
+             (s/conform ts/triple-spec
+                        '[[:p1 ?x1 :p2 ?x2] :q "w"]))))))

--- a/src/test/com/yetanalytics/flint/spec/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/triple_test.cljc
@@ -8,23 +8,23 @@
     (is (= '[:triple/spo
              [[[:ax/var ?s]
                [:triple/po [[[:ax/var ?p]
-                             [:triple/o [[:triple/object [:ax/var ?o]]]]]]]]]]
+                             [:triple/o [[:ax/var ?o]]]]]]]]]
            (s/conform ts/normal-form-spec '{?s {?p #{?o}}})))
     (is (= '[:triple/spo
              [[[:ax/var ?s1]
                [:triple/po [[[:ax/var ?p1]
-                             [:triple/o [[:triple/object [:ax/var ?o1]]
-                                         [:triple/object [:ax/var ?o2]]]]]
+                             [:triple/o [[:ax/var ?o1]
+                                         [:ax/var ?o2]]]]
                             [[:ax/var ?p2]
-                             [:triple/o [[:triple/object [:ax/var ?o1]]
-                                         [:triple/object [:ax/var ?o2]]]]]]]]
+                             [:triple/o [[:ax/var ?o1]
+                                         [:ax/var ?o2]]]]]]]
               [[:ax/var ?s2]
                [:triple/po [[[:ax/var ?p1]
-                             [:triple/o [[:triple/object [:ax/var ?o1]]
-                                         [:triple/object [:ax/var ?o2]]]]]
+                             [:triple/o [[:ax/var ?o1]
+                                         [:ax/var ?o2]]]]
                             [[:ax/var ?p2]
-                             [:triple/o [[:triple/object [:ax/var ?o1]]
-                                         [:triple/object [:ax/var ?o2]]]]]]]]]]
+                             [:triple/o [[:ax/var ?o1]
+                                         [:ax/var ?o2]]]]]]]]]
            (s/conform ts/normal-form-spec '{?s1 {?p1 #{?o1 ?o2}
                                                  ?p2 #{?o1 ?o2}}
                                             ?s2 {?p1 #{?o1 ?o2}
@@ -40,7 +40,7 @@
                                     [:path/paths
                                      [[:path/terminal [:ax/prefix-iri :x/one]]
                                       [:path/terminal [:ax/prefix-iri :x/two]]]]]]]
-                    [:triple/o [[:triple/object [:ax/var ?o]]]]]]]]]]
+                    [:triple/o [[:ax/var ?o]]]]]]]]]
              (s/conform ts/normal-form-spec
                         '{?s {(cat :x/one :x/two) #{?o}}})))
       (is (= '[[:ax/var ?s]

--- a/src/test/com/yetanalytics/flint/spec/triple_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/triple_test.cljc
@@ -57,5 +57,6 @@
       (is (->> '{?s {(cat :x/one :x/two) #{?o}}}
                (s/explain-data ts/normal-form-nopath-spec)
                ::s/problems
+               (filter #(-> % :path first (= :triple/spo)))
                (map :val)
                (every? (partial = '(cat :x/one :x/two))))))))

--- a/src/test/com/yetanalytics/flint/spec/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/update_test.cljc
@@ -5,24 +5,24 @@
 
 (deftest conform-update-test
   (testing "Conforming updates"
-    (is (= '[[:insert-data [[:triple/vec [[:ax/prefix-iri :foo/x]
-                                          [:ax/prefix-iri :dc/title]
-                                          [:ax/literal "Title"]]]
-                            [:triple/vec [[:ax/prefix-iri :foo/y]
-                                          [:ax/rdf-type :a]
-                                          [:ax/literal "MyType"]]]]]]
+    (is (= '[[:insert-data [[:triple.vec/spo [[:ax/prefix-iri :foo/x]
+                                              [:ax/prefix-iri :dc/title]
+                                              [:ax/literal "Title"]]]
+                            [:triple.vec/spo [[:ax/prefix-iri :foo/y]
+                                              [:ax/rdf-type :a]
+                                              [:ax/literal "MyType"]]]]]]
            (s/conform us/insert-data-update-spec
                       '{:insert-data [[:foo/x :dc/title "Title"]
                                       [:foo/y :a "MyType"]]})))
     (is (= '[[:delete-data [[:triple/quads
                              [[:ax/iri "<http://example.org>"]
                               [:triple/quad-triples
-                               [[:triple/vec [[:ax/prefix-iri :foo/x]
-                                              [:ax/prefix-iri :dc/title]
-                                              [:ax/literal "Title"]]]
-                                [:triple/vec [[:ax/prefix-iri :foo/y]
-                                              [:ax/rdf-type :a]
-                                              [:ax/literal "MyType"]]]]]]]]]]
+                               [[:triple.vec/spo [[:ax/prefix-iri :foo/x]
+                                                  [:ax/prefix-iri :dc/title]
+                                                  [:ax/literal "Title"]]]
+                                [:triple.vec/spo [[:ax/prefix-iri :foo/y]
+                                                  [:ax/rdf-type :a]
+                                                  [:ax/literal "MyType"]]]]]]]]]]
            (s/conform us/delete-data-update-spec
                       '{:delete-data [[:graph
                                        "<http://example.org>"

--- a/src/test/com/yetanalytics/flint/spec/update_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/update_test.cljc
@@ -14,9 +14,9 @@
            (s/conform us/insert-data-update-spec
                       '{:insert-data [[:foo/x :dc/title "Title"]
                                       [:foo/y :a "MyType"]]})))
-    (is (= '[[:delete-data [[:triple/quads
+    (is (= '[[:delete-data [[:triple.quad/gspo
                              [[:ax/iri "<http://example.org>"]
-                              [:triple/quad-triples
+                              [:triple.quad/spo
                                [[:triple.vec/spo [[:ax/prefix-iri :foo/x]
                                                   [:ax/prefix-iri :dc/title]
                                                   [:ax/literal "Title"]]]

--- a/src/test/com/yetanalytics/flint/spec/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/where_test.cljc
@@ -8,17 +8,17 @@
     (is (= '[:where-sub/select
              [[:select [:select/var-or-exprs [[:ax/var ?s]]]]
               [:where [:where-sub/where [[:where/triple
-                                          [:triple/vec [[:ax/var ?s]
-                                                        [:ax/var ?p]
-                                                        [:ax/var ?o]]]]]]]]]
+                                          [:triple.vec/spo [[:ax/var ?s]
+                                                            [:ax/var ?p]
+                                                            [:ax/var ?o]]]]]]]]]
            (s/conform ::ws/where '{:where [[?s ?p ?o]]
                                    :select [?s]})))
     (is (= '[:where-sub/select
              [[:select [:select/var-or-exprs [[:ax/var ?s]]]]
               [:where [:where-sub/where [[:where/triple
-                                          [:triple/vec [[:ax/var ?s]
-                                                        [:ax/var ?p]
-                                                        [:ax/var ?o]]]]]]]
+                                          [:triple.vec/spo [[:ax/var ?s]
+                                                            [:ax/var ?p]
+                                                            [:ax/var ?o]]]]]]]
               [:group-by [[:mod/expr-as-var
                            [:expr/as-var
                             [[:expr/branch
@@ -33,43 +33,43 @@
              [[:where/special
                [:where/union
                 [[:where-sub/where
-                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]
-                   [:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]
+                  [[:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]
+                   [:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]
                  [:where-sub/where
-                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
+                  [[:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
            (s/conform ::ws/where '[[:union [[?s ?p ?o] [?s ?p ?o]] [[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/optional
                 [:where-sub/where
-                 [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
+                 [[:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
            (s/conform ::ws/where [[:optional '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/minus
                 [:where-sub/where
-                 [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
+                 [[:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
            (s/conform ::ws/where [[:minus '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/graph
                 [[:ax/prefix-iri :foo/my-graph]
                  [:where-sub/where
-                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
+                  [[:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
            (s/conform ::ws/where [[:graph :foo/my-graph '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/service
                 [[:ax/prefix-iri :foo/my-uri]
                  [:where-sub/where
-                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
+                  [[:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
            (s/conform ::ws/where [[:service :foo/my-uri '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/service-silent
                 [[:ax/prefix-iri :foo/my-uri]
                  [:where-sub/where
-                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
+                  [[:where/triple [:triple.vec/spo [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
            (s/conform ::ws/where [[:service-silent :foo/my-uri '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
@@ -100,9 +100,9 @@
     ;; This is not a special form since it does not conform to the UNION
     ;; spec (or any other special form spec really)
     (is (= '[:where-sub/where
-             [[:where/triple [:triple/vec [[:ax/prefix-iri :union]
-                                           [:ax/prefix-iri :foo/bar]
-                                           [:ax/prefix-iri :baz/qux]]]]]]
+             [[:where/triple [:triple.vec/spo [[:ax/prefix-iri :union]
+                                               [:ax/prefix-iri :foo/bar]
+                                               [:ax/prefix-iri :baz/qux]]]]]]
            (s/conform ::ws/where '[[:union :foo/bar :baz/qux]])))))
 
 (deftest invalid-where-test

--- a/src/test/com/yetanalytics/flint/spec/where_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/where_test.cljc
@@ -7,16 +7,18 @@
   (testing "Conforming WHERE clauses"
     (is (= '[:where-sub/select
              [[:select [:select/var-or-exprs [[:ax/var ?s]]]]
-              [:where [:where-sub/where [[:triple/vec [[:ax/var ?s]
-                                                       [:ax/var ?p]
-                                                       [:ax/var ?o]]]]]]]]
+              [:where [:where-sub/where [[:where/triple
+                                          [:triple/vec [[:ax/var ?s]
+                                                        [:ax/var ?p]
+                                                        [:ax/var ?o]]]]]]]]]
            (s/conform ::ws/where '{:where [[?s ?p ?o]]
                                    :select [?s]})))
     (is (= '[:where-sub/select
              [[:select [:select/var-or-exprs [[:ax/var ?s]]]]
-              [:where [:where-sub/where [[:triple/vec [[:ax/var ?s]
-                                                       [:ax/var ?p]
-                                                       [:ax/var ?o]]]]]]
+              [:where [:where-sub/where [[:where/triple
+                                          [:triple/vec [[:ax/var ?s]
+                                                        [:ax/var ?p]
+                                                        [:ax/var ?o]]]]]]]
               [:group-by [[:mod/expr-as-var
                            [:expr/as-var
                             [[:expr/branch
@@ -31,37 +33,43 @@
              [[:where/special
                [:where/union
                 [[:where-sub/where
-                  [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]
-                   [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]
-                 [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
+                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]
+                   [:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]
+                 [:where-sub/where
+                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
            (s/conform ::ws/where '[[:union [[?s ?p ?o] [?s ?p ?o]] [[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/optional
-                [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]
+                [:where-sub/where
+                 [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
            (s/conform ::ws/where [[:optional '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/minus
-                [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]
+                [:where-sub/where
+                 [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
            (s/conform ::ws/where [[:minus '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/graph
                 [[:ax/prefix-iri :foo/my-graph]
-                 [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
+                 [:where-sub/where
+                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
            (s/conform ::ws/where [[:graph :foo/my-graph '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/service
                 [[:ax/prefix-iri :foo/my-uri]
-                 [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
+                 [:where-sub/where
+                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
            (s/conform ::ws/where [[:service :foo/my-uri '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
                [:where/service-silent
                 [[:ax/prefix-iri :foo/my-uri]
-                 [:where-sub/where [[:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]
+                 [:where-sub/where
+                  [[:where/triple [:triple/vec [[:ax/var ?s] [:ax/var ?p] [:ax/var ?o]]]]]]]]]]]
            (s/conform ::ws/where [[:service-silent :foo/my-uri '[[?s ?p ?o]]]])))
     (is (= '[:where-sub/where
              [[:where/special
@@ -92,9 +100,9 @@
     ;; This is not a special form since it does not conform to the UNION
     ;; spec (or any other special form spec really)
     (is (= '[:where-sub/where
-             [[:triple/vec [[:ax/prefix-iri :union]
-                            [:ax/prefix-iri :foo/bar]
-                            [:ax/prefix-iri :baz/qux]]]]]
+             [[:where/triple [:triple/vec [[:ax/prefix-iri :union]
+                                           [:ax/prefix-iri :foo/bar]
+                                           [:ax/prefix-iri :baz/qux]]]]]]
            (s/conform ::ws/where '[[:union :foo/bar :baz/qux]])))))
 
 (deftest invalid-where-test

--- a/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
@@ -49,6 +49,12 @@
                            [:where [[?y :baz/qux _]]]]}
                 (s/conform qs/query-spec)
                 v/collect-nodes
+                vb/validate-bnodes)))
+    (is (= [#{} nil]
+           (->> '{:select [?p]
+                  :where  [[?x ?y] ?p (?z ?w)]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
                 vb/validate-bnodes))))
   (testing "invalid blank nodes"
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-bgp

--- a/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
@@ -53,9 +53,9 @@
   (testing "invalid blank nodes"
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]
                            [:where [[?y :baz/qux _1]]]]}
@@ -64,13 +64,13 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
-                             {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                              {:bnode '_1
                               :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                             {:bnode '_1
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{?x {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -81,17 +81,17 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1 '_2} {:kind ::vb/dupe-bnodes-bgp
                         :errors [{:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                                  {:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
-                                 {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
-                                 {:bnode '_1
                                   :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                                  {:bnode '_1
                                   :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
+                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                                 {:bnode '_1
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                                 {:bnode '_1
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{_2 {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -102,9 +102,9 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?y :baz/qux _1]]]]}
@@ -113,11 +113,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 2 :where/special :where/optional :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where 1 :where/triple]}
                              {:bnode '_1
                               :path  [:query/select :where :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where 2 :where/special :where/optional :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [?y :baz/qux _1]
@@ -127,11 +127,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/triple]}
+                              :path  [:query/select :where :where-sub/where 0 :where/triple]}
                              {:bnode '_1
                               :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where 2 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?z :far/lands _1]]]
@@ -139,13 +139,25 @@
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 vb/validate-bnodes)))
+    (is (= [#{'_1 '_2} {:kind ::vb/dupe-bnodes-bgp
+                        :errors [{:bnode '_2
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}
+                                 {:bnode '_2
+                                  :path  [:query/select :where :where-sub/where 2 :where/triple]}]}]
+           (->> '{:select [?x]
+                  :where  [[?x :foo/bar _1]
+                           [:optional [[?z :far/lands _2]]]
+                           [?y :baz/qux _2]]}
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
                               :path  [:query/select :where :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/filter :expr/branch :expr/args :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where 2 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/filter :expr/branch :expr/args :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:filter (not-exists [[?z :far/lands _1]])]
@@ -164,9 +176,9 @@
                 (vb/validate-bnodes #{'_1}))))
     (is (= [[#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                      :errors [{:bnode '_1
-                               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                               :path  [:update/modify :insert]}
                               {:bnode '_1
-                               :path  [:update/modify :insert]}]}]]
+                               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]]
            (->> '[{:insert [[?x :foo/bar _1]]
                    :where  [[:where [[?x :foo/bar _1]]]]}]
                 (map (partial s/conform us/update-spec))

--- a/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
@@ -53,9 +53,9 @@
   (testing "invalid blank nodes"
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]
                            [:where [[?y :baz/qux _1]]]]}
@@ -64,13 +64,13 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{?x {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -81,17 +81,17 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1 '_2} {:kind ::vb/dupe-bnodes-bgp
                         :errors [{:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                                  {:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}
+                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]}]
+                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{_2 {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -102,9 +102,9 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0]}]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?y :baz/qux _1]]]]}
@@ -113,11 +113,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 2 :where/special :where/optional :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 2 :where/special :where/optional :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0]}]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [?y :baz/qux _1]
@@ -127,11 +127,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1]}
+                              :path  [:query/select :where :where-sub/where 1 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0]}]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?z :far/lands _1]]]
@@ -141,11 +141,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/filter :expr/branch :expr/args :where-sub/where 0]}
+                              :path  [:query/select :where :where-sub/where 1 :where/special :where/filter :expr/branch :expr/args :where-sub/where 0 :where/triple]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0]}]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/triple]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:filter (not-exists [[?z :far/lands _1]])]
@@ -155,7 +155,7 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-update
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]
+                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]
                     :prev-bnodes #{'_1}}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]]}
@@ -164,7 +164,7 @@
                 (vb/validate-bnodes #{'_1}))))
     (is (= [[#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                      :errors [{:bnode '_1
-                               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}
+                               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
                               {:bnode '_1
                                :path  [:update/modify :insert]}]}]]
            (->> '[{:insert [[?x :foo/bar _1]]
@@ -188,7 +188,7 @@
              [{:bnode '_1
                :path  [:update/modify :insert]}
               {:bnode '_2
-               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0]}]
+               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]
              :prev-bnodes
              #{'_1 '_2}}]
            (->> '[{:insert [[?x :foo/bar _1]]

--- a/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
@@ -53,9 +53,9 @@
   (testing "invalid blank nodes"
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}]}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]
                            [:where [[?y :baz/qux _1]]]]}
@@ -64,13 +64,13 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{?x {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -81,17 +81,17 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1 '_2} {:kind ::vb/dupe-bnodes-bgp
                         :errors [{:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo]}
                                  {:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
                                  {:bnode '_1
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{_2 {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -102,9 +102,9 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple/vec]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?y :baz/qux _1]]]]}
@@ -113,11 +113,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 2 :where/special :where/optional :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple/vec]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [?y :baz/qux _1]
@@ -127,11 +127,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple/vec]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 2 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?z :far/lands _1]]]
@@ -141,9 +141,9 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1 '_2} {:kind ::vb/dupe-bnodes-bgp
                         :errors [{:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 1 :where/special :where/optional :where-sub/where 0 :where/triple]}
+                                  :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple/vec]}
                                  {:bnode '_2
-                                  :path  [:query/select :where :where-sub/where 2 :where/triple]}]}]
+                                  :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?z :far/lands _2]]]
@@ -153,11 +153,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 2 :where/triple]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where 1 :where/special :where/filter :expr/branch :expr/args :where-sub/where 0 :where/triple]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/filter :expr/branch :expr/args :where-sub/where :where/triple :triple/vec]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:filter (not-exists [[?z :far/lands _1]])]
@@ -167,7 +167,7 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-update
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}]
                     :prev-bnodes #{'_1}}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]]}
@@ -176,9 +176,9 @@
                 (vb/validate-bnodes #{'_1}))))
     (is (= [[#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                      :errors [{:bnode '_1
-                               :path  [:update/modify :insert]}
+                               :path  [:update/modify :insert :triple/vec]}
                               {:bnode '_1
-                               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]}]]
+                               :path  [:update/modify :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}]}]]
            (->> '[{:insert [[?x :foo/bar _1]]
                    :where  [[:where [[?x :foo/bar _1]]]]}]
                 (map (partial s/conform us/update-spec))
@@ -198,9 +198,9 @@
              ::vb/dupe-bnodes-update
              :errors
              [{:bnode '_1
-               :path  [:update/modify :insert]}
+               :path  [:update/modify :insert :triple/vec]}
               {:bnode '_2
-               :path  [:update/modify :where :where-sub/where 0 :where/special :where/recurse :where-sub/where 0 :where/triple]}]
+               :path  [:update/modify :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}]
              :prev-bnodes
              #{'_1 '_2}}]
            (->> '[{:insert [[?x :foo/bar _1]]

--- a/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
@@ -64,13 +64,13 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo :triple.nform/po :triple.nform/o]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo :triple.nform/po :triple.nform/o]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo :triple.nform/po :triple.nform/o]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo :triple.nform/po :triple.nform/o]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{?x {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -81,17 +81,17 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1 '_2} {:kind ::vb/dupe-bnodes-bgp
                         :errors [{:bnode '_2
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo]}
                                  {:bnode '_2
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo]}
                                  {:bnode '_1
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo :triple.nform/po :triple.nform/o]}
                                  {:bnode '_1
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo :triple.nform/po :triple.nform/o]}
                                  {:bnode '_1
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo :triple.nform/po :triple.nform/o]}
                                  {:bnode '_1
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}]}]
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.nform/spo :triple.nform/po :triple.nform/o]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{_2 {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]

--- a/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
@@ -53,9 +53,9 @@
   (testing "invalid blank nodes"
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.vec/spo]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.vec/spo]}]}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]
                            [:where [[?y :baz/qux _1]]]]}
@@ -102,9 +102,9 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple.vec/spo]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple/vec]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple.vec/spo]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?y :baz/qux _1]]]]}
@@ -113,11 +113,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple.vec/spo]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple.vec/spo]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple/vec]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple.vec/spo]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [?y :baz/qux _1]
@@ -127,11 +127,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple.vec/spo]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple/vec]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple.vec/spo]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}]}]
+                              :path  [:query/select :where :where-sub/where :where/triple :triple.vec/spo]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?z :far/lands _1]]]
@@ -141,9 +141,9 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1 '_2} {:kind ::vb/dupe-bnodes-bgp
                         :errors [{:bnode '_2
-                                  :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple/vec]}
+                                  :path  [:query/select :where :where-sub/where :where/special :where/optional :where-sub/where :where/triple :triple.vec/spo]}
                                  {:bnode '_2
-                                  :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}]}]
+                                  :path  [:query/select :where :where-sub/where :where/triple :triple.vec/spo]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:optional [[?z :far/lands _2]]]
@@ -153,11 +153,11 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple.vec/spo]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/triple :triple/vec]}
+                              :path  [:query/select :where :where-sub/where :where/triple :triple.vec/spo]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/filter :expr/branch :expr/args :where-sub/where :where/triple :triple/vec]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/filter :expr/branch :expr/args :where-sub/where :where/triple :triple.vec/spo]}]}]
            (->> '{:select [?x]
                   :where  [[?x :foo/bar _1]
                            [:filter (not-exists [[?z :far/lands _1]])]
@@ -167,7 +167,7 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind   ::vb/dupe-bnodes-update
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.vec/spo]}]
                     :prev-bnodes #{'_1}}]
            (->> '{:select [?x]
                   :where  [[:where [[?x :foo/bar _1]]]]}
@@ -176,9 +176,9 @@
                 (vb/validate-bnodes #{'_1}))))
     (is (= [[#{'_1} {:kind   ::vb/dupe-bnodes-bgp
                      :errors [{:bnode '_1
-                               :path  [:update/modify :insert :triple/vec]}
+                               :path  [:update/modify :insert :triple.vec/spo]}
                               {:bnode '_1
-                               :path  [:update/modify :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}]}]]
+                               :path  [:update/modify :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.vec/spo]}]}]]
            (->> '[{:insert [[?x :foo/bar _1]]
                    :where  [[:where [[?x :foo/bar _1]]]]}]
                 (map (partial s/conform us/update-spec))
@@ -198,9 +198,9 @@
              ::vb/dupe-bnodes-update
              :errors
              [{:bnode '_1
-               :path  [:update/modify :insert :triple/vec]}
+               :path  [:update/modify :insert :triple.vec/spo]}
               {:bnode '_2
-               :path  [:update/modify :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/vec]}]
+               :path  [:update/modify :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple.vec/spo]}]
              :prev-bnodes
              #{'_1 '_2}}]
            (->> '[{:insert [[?x :foo/bar _1]]

--- a/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/bnode_test.cljc
@@ -64,13 +64,13 @@
                 vb/validate-bnodes)))
     (is (= [#{'_1} {:kind ::vb/dupe-bnodes-bgp
                     :errors [{:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
                              {:bnode '_1
-                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}]}]
+                              :path  [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{?x {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]
@@ -85,13 +85,13 @@
                                  {:bnode '_2
                                   :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo]}
                                  {:bnode '_1
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
                                  {:bnode '_1
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
                                  {:bnode '_1
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}
                                  {:bnode '_1
-                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o :triple/object]}]}]
+                                  :path [:query/select :where :where-sub/where :where/special :where/recurse :where-sub/where :where/triple :triple/nform :triple/spo :triple/po :triple/o]}]}]
            (->> '{:select [?x]
                   :where  [[:where [{_2 {:foo/bar #{_1}
                                          :baz/qux #{_1}}}]]

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -26,7 +26,7 @@
     (is (= [{:iri :bar
              :prefix :$
              :prefixes {:foo "<http://foo.org/>"}
-             :path [:query/select :where :where-sub/where :triple/vec :ax/prefix-iri]}]
+             :path [:query/select :where :where-sub/where :where/triple :triple/vec :ax/prefix-iri]}]
            (->> (assoc query :where '[[:bar :a ?y]])
                 (s/conform qs/query-spec)
                 v/collect-nodes
@@ -34,15 +34,15 @@
     (is (= [{:iri      :fee/bar
              :prefix   :fee
              :prefixes {:foo "<http://foo.org/>"}
-             :path     [:query/select :where :where-sub/where :triple/vec :ax/prefix-iri]}
+             :path     [:query/select :where :where-sub/where :where/triple :triple/vec :ax/prefix-iri]}
             {:iri      :fii/bar
              :prefix   :fii
              :prefixes {:foo "<http://foo.org/>"}
-             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :triple/vec :ax/prefix-iri]}
+             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :where/triple :triple/vec :ax/prefix-iri]}
             {:iri      :fum/bar
              :prefix   :fum
              :prefixes {:foo "<http://foo.org/>"}
-             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :triple/vec :ax/prefix-iri]}]
+             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :where/triple :triple/vec :ax/prefix-iri]}]
            (->> query
                 (s/conform qs/query-spec)
                 v/collect-nodes

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -50,11 +50,11 @@
     (is (= [{:iri :baz/Qux
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
-             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple.nform/spo :triple.nform/po :triple.nform/o :ax/prefix-iri]}
+             :path [:update/insert-data :insert-data :triple.quad/gspo :triple.quad/spo :triple.nform/spo :triple.nform/po :triple.nform/o :ax/prefix-iri]}
             {:iri :baz/Quu
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
-             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple.vec/spo :ax/prefix-iri]}]
+             :path [:update/insert-data :insert-data :triple.quad/gspo :triple.quad/spo :triple.vec/spo :ax/prefix-iri]}]
            (->> {:prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
                  :insert-data [[:graph "<http://foo.org>"
                                 [{"<http://bar.org>" {:rdf/type #{:baz/Qux}}}

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -26,7 +26,7 @@
     (is (= [{:iri :bar
              :prefix :$
              :prefixes {:foo "<http://foo.org/>"}
-             :path [:query/select :where :where-sub/where :where/triple :triple/vec :ax/prefix-iri]}]
+             :path [:query/select :where :where-sub/where :where/triple :triple.vec/spo :ax/prefix-iri]}]
            (->> (assoc query :where '[[:bar :a ?y]])
                 (s/conform qs/query-spec)
                 v/collect-nodes
@@ -34,15 +34,15 @@
     (is (= [{:iri      :fee/bar
              :prefix   :fee
              :prefixes {:foo "<http://foo.org/>"}
-             :path     [:query/select :where :where-sub/where :where/triple :triple/vec :ax/prefix-iri]}
+             :path     [:query/select :where :where-sub/where :where/triple :triple.vec/spo :ax/prefix-iri]}
             {:iri      :fii/bar
              :prefix   :fii
              :prefixes {:foo "<http://foo.org/>"}
-             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :where/triple :triple/vec :ax/prefix-iri]}
+             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :where/triple :triple.vec/spo :ax/prefix-iri]}
             {:iri      :fum/bar
              :prefix   :fum
              :prefixes {:foo "<http://foo.org/>"}
-             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :where/triple :triple/vec :ax/prefix-iri]}]
+             :path     [:query/select :where :where-sub/where :where/special :where/union :where-sub/where :where/triple :triple.vec/spo :ax/prefix-iri]}]
            (->> query
                 (s/conform qs/query-spec)
                 v/collect-nodes
@@ -54,7 +54,7 @@
             {:iri :baz/Quu
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
-             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/vec :ax/prefix-iri]}]
+             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple.vec/spo :ax/prefix-iri]}]
            (->> {:prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
                  :insert-data [[:graph "<http://foo.org>"
                                 [{"<http://bar.org>" {:rdf/type #{:baz/Qux}}}

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -50,7 +50,7 @@
     (is (= [{:iri :baz/Qux
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
-             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/nform :triple/spo :triple/po :triple/o :triple/object :ax/prefix-iri]}
+             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/nform :triple/spo :triple/po :triple/o :ax/prefix-iri]}
             {:iri :baz/Quu
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -23,11 +23,24 @@
                    v/collect-nodes
                    (vp/validate-prefixes (assoc (:prefixes query)
                                                 :$ "<http://default.org>")))))
-    (is (= [{:iri :bar
-             :prefix :$
+    (is (= [{:iri      :bar
+             :prefix   :$
              :prefixes {:foo "<http://foo.org/>"}
-             :path [:query/select :where :where-sub/where :where/triple :triple.vec/spo :ax/prefix-iri]}]
+             :path     [:query/select :where :where-sub/where :where/triple :triple.vec/spo :ax/prefix-iri]}]
            (->> (assoc query :where '[[:bar :a ?y]])
+                (s/conform qs/query-spec)
+                v/collect-nodes
+                (vp/validate-prefixes (:prefixes query)))))
+    (is (= [{:iri      :bar
+             :prefix   :$
+             :prefixes {:foo "<http://foo.org/>"}
+             :path     [:query/select :where :where-sub/where :where/triple :triple.vec/spo :triple/bnodes :ax/prefix-iri]}
+            {:iri      :bee
+             :prefix   :$
+             :prefixes {:foo "<http://foo.org/>"}
+             :path     [:query/select :where :where-sub/where :where/triple :triple.vec/spo :triple/bnodes :ax/prefix-iri]}]
+           (->> (assoc query :where '[[[:bar ?x] :a ?y]
+                                      [?z :a [:bee ?w]]])
                 (s/conform qs/query-spec)
                 v/collect-nodes
                 (vp/validate-prefixes (:prefixes query)))))

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -50,7 +50,7 @@
     (is (= [{:iri :baz/Qux
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
-             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/nform :triple/spo :triple/po :triple/o :ax/prefix-iri]}
+             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/nform :triple/spo :triple/po :triple/o :triple/object :ax/prefix-iri]}
             {:iri :baz/Quu
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}

--- a/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/prefix_test.cljc
@@ -50,16 +50,15 @@
     (is (= [{:iri :baz/Qux
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
-             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/nform :triple/spo :triple/po :triple/o :ax/prefix-iri]}
+             :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple.nform/spo :triple.nform/po :triple.nform/o :ax/prefix-iri]}
             {:iri :baz/Quu
              :prefix :baz
              :prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
              :path [:update/insert-data :insert-data :triple/quads :triple/quad-triples :triple/vec :ax/prefix-iri]}]
-           (->>
-            {:prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
-             :insert-data [[:graph "<http://foo.org>"
-                            [{"<http://bar.org>" {:rdf/type #{:baz/Qux}}}
-                             ["<http://bar.org>" :rdf/type :baz/Quu]]]]}
-            (s/conform us/update-spec)
-            v/collect-nodes
-            (vp/validate-prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}))))))
+           (->> {:prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}
+                 :insert-data [[:graph "<http://foo.org>"
+                                [{"<http://bar.org>" {:rdf/type #{:baz/Qux}}}
+                                 ["<http://bar.org>" :rdf/type :baz/Quu]]]]}
+                (s/conform us/update-spec)
+                v/collect-nodes
+                (vp/validate-prefixes {:rdf "<http://www.w3.org/1999/02/22-rdf-syntax-ns#>"}))))))

--- a/src/test/com/yetanalytics/flint/validate/scope_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/scope_test.cljc
@@ -69,7 +69,20 @@
                                  [:path/paths
                                   [[:path/terminal [:ax/var ?ya]]
                                    [:path/terminal [:ax/var ?yb]]]]]]]
-                 [:ax/var ?z]]]))))
+                 [:ax/var ?z]]])))
+      (is (= '[?x1 ?x2 ?y ?z1 ?z2]
+             (vv/get-scope-vars
+              '[:triple.vec/spo [[:triple/list [[:ax/var ?x1] [:ax/var ?x2]]]
+                                 [:ax/var ?y]
+                                 [:triple/bnodes [[[:ax/var ?z1] [:ax/var ?z2]]]]]])))
+      (is (= '[?x1 ?x2 ?y ?z1 ?z2]
+             (vv/get-scope-vars
+              '[:triple.nform/spo
+                [[[:triple/list [[:ax/var ?x1] [:ax/var ?x2]]]
+                  [:triple.nform/po
+                   [[[:ax/var ?y]
+                     [:triple.nform/o
+                      [[:triple/bnodes [[[:ax/var ?z1] [:ax/var ?z2]]]]]]]]]]]]))))
     (testing "in sub-SELECT queries"
       (is (= '[?x ?y ?z]
              (vv/get-scope-vars

--- a/src/test/com/yetanalytics/flint/validate/scope_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/scope_test.cljc
@@ -45,7 +45,7 @@
                 [:triple/spo
                  [[[:ax/var ?s]
                    [:triple/po [[[:ax/var ?p]
-                                 [:triple/o [[:ax/var ?o]]]]]]]]]])))
+                                 [:triple/o [[:triple/object [:ax/var ?o]]]]]]]]]]])))
       (is (= '[?x ?y ?z]
              (vv/get-scope-vars
               '[:where-sub/where

--- a/src/test/com/yetanalytics/flint/validate/scope_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/scope_test.cljc
@@ -36,9 +36,9 @@
     (testing "in basic graph patterns"
       (is (= '[?x ?y ?z]
              (vv/get-scope-vars
-              '[:triple/vec [[:ax/var ?x]
-                             [:ax/var ?y]
-                             [:ax/var ?z]]])))
+              '[:triple.vec/spo [[:ax/var ?x]
+                                 [:ax/var ?y]
+                                 [:ax/var ?z]]])))
       (is (= '[?s ?p ?o]
              (vv/get-scope-vars
               '[:triple.nform/spo
@@ -50,19 +50,19 @@
              (vv/get-scope-vars
               '[:where-sub/where
                 [[:where/triple
-                  [:triple/vec [[:ax/var ?x]
-                                [:ax/var ?y]
-                                [:ax/var ?z]]]]]])))
+                  [:triple.vec/spo [[:ax/var ?x]
+                                    [:ax/var ?y]
+                                    [:ax/var ?z]]]]]])))
       (is (= '[?x ?y ?z]
              (vv/get-scope-vars
               '[:where-sub/where
                 [[:where/triple
-                  [:triple/vec [[:ax/var ?x]
-                                [:ax/var ?y]
-                                [:ax/var ?z]]]]]])))
+                  [:triple.vec/spo [[:ax/var ?x]
+                                    [:ax/var ?y]
+                                    [:ax/var ?z]]]]]])))
       (is (= '[?x ?ya ?yb ?z]
              (vv/get-scope-vars
-              '[:triple/vec
+              '[:triple.vec/spo
                 [[:ax/var ?x]
                  [:triple/path
                   [:path/branch [[:path/op cat]
@@ -77,9 +77,9 @@
                 [[:select [:ax/wildcard '*]]
                  [:where [:where-sub/where
                           [[:where/triple
-                            [:triple/vec [[:ax/var ?x]
-                                          [:ax/var ?y]
-                                          [:ax/var ?z]]]]]]]]])))
+                            [:triple.vec/spo [[:ax/var ?x]
+                                              [:ax/var ?y]
+                                              [:ax/var ?z]]]]]]]]])))
       ;; This is an illegal sub-SELECT since it has both a wildcard and
       ;; GROUP BY, but we want to cover all of our bases.
       (is (= '[?x ?y ?z ?w]
@@ -88,9 +88,9 @@
                 [[:select [:ax/wildcard '*]]
                  [:where [:where-sub/where
                           [[:where/triple
-                            [:triple/vec [[:ax/var ?x]
-                                          [:ax/var ?y]
-                                          [:ax/var ?z]]]]]]]
+                            [:triple.vec/spo [[:ax/var ?x]
+                                              [:ax/var ?y]
+                                              [:ax/var ?z]]]]]]]
                  [:group-by [[:ax/var ?w]]]]])))
       (is (= '[?a ?b ?c]
              (vv/get-scope-vars
@@ -103,9 +103,9 @@
                                             [:ax/var ?c]]]]]]]
                  [:where [:where-sub/where
                           [[:where/triple
-                            [:triple/vec [[:ax/var ?x]
-                                          [:ax/var ?y]
-                                          [:ax/var ?z]]]]]]]
+                            [:triple.vec/spo [[:ax/var ?x]
+                                              [:ax/var ?y]
+                                              [:ax/var ?z]]]]]]]
                  [:group-by [[:ax/var ?a]
                              [:ax/var ?b]
                              [:ax/var ?c]]]]]))))
@@ -123,39 +123,39 @@
               [[:where/recurse
                 [:where-sub/where
                  [[:where/triple
-                   [:triple/vec
+                   [:triple.vec/spo
                     [[:ax/var ?s1] [:ax/var ?p1] [:ax/var ?o1]]]]]]]
                [:where/union
                 [[:where-sub/where
                   [[:where/triple
-                    [:triple/vec
+                    [:triple.vec/spo
                      [[:ax/var ?s2] [:ax/var ?p2] [:ax/var ?o2]]]]]]
                  [:where-sub/where
                   [[:where/triple
-                    [:triple/vec
+                    [:triple.vec/spo
                      [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]]]
                [:where/optional
                 [:where-sub/where
                  [[:where/triple
-                   [:triple/vec
+                   [:triple.vec/spo
                     [[:ax/var ?s4] [:ax/var ?p4] [:ax/var ?o4]]]]]]]
                [:where/graph
                 [[:ax/var ?graphTerm]
                  [:where-sub/where
                   [[:where/triple
-                    [:triple/vec
+                    [:triple.vec/spo
                      [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]
                [:where/service
                 [[:ax/var ?serviceTerm]
                  [:where-sub/where
                   [[:where/triple
-                    [:triple/vec
+                    [:triple.vec/spo
                      [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]]]
                [:where/service-silent
                 [[:ax/var ?serviceSilentTerm]
                  [:where-sub/where
                   [[:where/triple
-                    [:triple/vec
+                    [:triple.vec/spo
                      [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]]]
                [:where/bind
                 [:expr/as-var
@@ -177,7 +177,7 @@
                [:where/minus
                 [:where-sub/where
                  [[:where/triple
-                   [:triple/vec
+                   [:triple.vec/spo
                     [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]])))))
 
 

--- a/src/test/com/yetanalytics/flint/validate/scope_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/scope_test.cljc
@@ -49,15 +49,17 @@
       (is (= '[?x ?y ?z]
              (vv/get-scope-vars
               '[:where-sub/where
-                [[:triple/vec [[:ax/var ?x]
-                               [:ax/var ?y]
-                               [:ax/var ?z]]]]])))
+                [[:where/triple
+                  [:triple/vec [[:ax/var ?x]
+                                [:ax/var ?y]
+                                [:ax/var ?z]]]]]])))
       (is (= '[?x ?y ?z]
              (vv/get-scope-vars
               '[:where-sub/where
-                [[:triple/vec [[:ax/var ?x]
-                               [:ax/var ?y]
-                               [:ax/var ?z]]]]])))
+                [[:where/triple
+                  [:triple/vec [[:ax/var ?x]
+                                [:ax/var ?y]
+                                [:ax/var ?z]]]]]])))
       (is (= '[?x ?ya ?yb ?z]
              (vv/get-scope-vars
               '[:triple/vec
@@ -74,9 +76,10 @@
               '[:where-sub/select
                 [[:select [:ax/wildcard '*]]
                  [:where [:where-sub/where
-                          [[:triple/vec [[:ax/var ?x]
-                                         [:ax/var ?y]
-                                         [:ax/var ?z]]]]]]]])))
+                          [[:where/triple
+                            [:triple/vec [[:ax/var ?x]
+                                          [:ax/var ?y]
+                                          [:ax/var ?z]]]]]]]]])))
       ;; This is an illegal sub-SELECT since it has both a wildcard and
       ;; GROUP BY, but we want to cover all of our bases.
       (is (= '[?x ?y ?z ?w]
@@ -84,9 +87,10 @@
               '[:where-sub/select
                 [[:select [:ax/wildcard '*]]
                  [:where [:where-sub/where
-                          [[:triple/vec [[:ax/var ?x]
-                                         [:ax/var ?y]
-                                         [:ax/var ?z]]]]]]
+                          [[:where/triple
+                            [:triple/vec [[:ax/var ?x]
+                                          [:ax/var ?y]
+                                          [:ax/var ?z]]]]]]]
                  [:group-by [[:ax/var ?w]]]]])))
       (is (= '[?a ?b ?c]
              (vv/get-scope-vars
@@ -98,9 +102,10 @@
                              [:expr/as-var [[:expr/terminal [:ax/num-lit 2]]
                                             [:ax/var ?c]]]]]]]
                  [:where [:where-sub/where
-                          [[:triple/vec [[:ax/var ?x]
-                                         [:ax/var ?y]
-                                         [:ax/var ?z]]]]]]
+                          [[:where/triple
+                            [:triple/vec [[:ax/var ?x]
+                                          [:ax/var ?y]
+                                          [:ax/var ?z]]]]]]]
                  [:group-by [[:ax/var ?a]
                              [:ax/var ?b]
                              [:ax/var ?c]]]]]))))
@@ -117,33 +122,41 @@
             '[:where-sub/where
               [[:where/recurse
                 [:where-sub/where
-                 [[:triple/vec [[:ax/var ?s1] [:ax/var ?p1] [:ax/var ?o1]]]]]]
+                 [[:where/triple
+                   [:triple/vec
+                    [[:ax/var ?s1] [:ax/var ?p1] [:ax/var ?o1]]]]]]]
                [:where/union
                 [[:where-sub/where
-                  [[:triple/vec
-                    [[:ax/var ?s2] [:ax/var ?p2] [:ax/var ?o2]]]]]
+                  [[:where/triple
+                    [:triple/vec
+                     [[:ax/var ?s2] [:ax/var ?p2] [:ax/var ?o2]]]]]]
                  [:where-sub/where
-                  [[:triple/vec
-                    [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]]
+                  [[:where/triple
+                    [:triple/vec
+                     [[:ax/var ?s3] [:ax/var ?p3] [:ax/var ?o3]]]]]]]]
                [:where/optional
                 [:where-sub/where
-                 [[:triple/vec
-                   [[:ax/var ?s4] [:ax/var ?p4] [:ax/var ?o4]]]]]]
+                 [[:where/triple
+                   [:triple/vec
+                    [[:ax/var ?s4] [:ax/var ?p4] [:ax/var ?o4]]]]]]]
                [:where/graph
                 [[:ax/var ?graphTerm]
                  [:where-sub/where
-                  [[:triple/vec
-                    [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]
+                  [[:where/triple
+                    [:triple/vec
+                     [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]
                [:where/service
                 [[:ax/var ?serviceTerm]
                  [:where-sub/where
-                  [[:triple/vec
-                    [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]]
+                  [[:where/triple
+                    [:triple/vec
+                     [[:ax/var ?s6] [:ax/var ?p6] [:ax/var ?o6]]]]]]]]
                [:where/service-silent
                 [[:ax/var ?serviceSilentTerm]
                  [:where-sub/where
-                  [[:triple/vec
-                    [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]]
+                  [[:where/triple
+                    [:triple/vec
+                     [[:ax/var ?s7] [:ax/var ?p7] [:ax/var ?o7]]]]]]]]
                [:where/bind
                 [:expr/as-var
                  [[:expr/branch
@@ -163,8 +176,9 @@
                     [:expr/terminal [:ax/var ?bar]])]]]]
                [:where/minus
                 [:where-sub/where
-                 [[:triple/vec
-                   [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]])))))
+                 [[:where/triple
+                   [:triple/vec
+                    [[:ax/var ?s5] [:ax/var ?p5] [:ax/var ?o5]]]]]]]]])))))
 
 
 (deftest scope-validation-test

--- a/src/test/com/yetanalytics/flint/validate/scope_test.cljc
+++ b/src/test/com/yetanalytics/flint/validate/scope_test.cljc
@@ -41,11 +41,11 @@
                              [:ax/var ?z]]])))
       (is (= '[?s ?p ?o]
              (vv/get-scope-vars
-              '[:triple/nform
-                [:triple/spo
-                 [[[:ax/var ?s]
-                   [:triple/po [[[:ax/var ?p]
-                                 [:triple/o [[:triple/object [:ax/var ?o]]]]]]]]]]])))
+              '[:triple.nform/spo
+               [[[:ax/var ?s]
+                 [:triple.nform/po
+                  [[[:ax/var ?p]
+                    [:triple.nform/o [[:ax/var ?o]]]]]]]]])))
       (is (= '[?x ?y ?z]
              (vv/get-scope-vars
               '[:where-sub/where


### PR DESCRIPTION
Implement [lists](https://www.w3.org/TR/sparql11-query/#collections) and [blank node vectors](https://www.w3.org/TR/sparql11-query/#QSynBlankNodes) for SPARQL triples, to address #32 

This also involves the following auxilary work:
- Rework triples-related AST structure
- Rework the blank node validation to simplify it and support the reworked AST