### PR TITLE
Disallow syntax quoting for symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for blank node vector syntactic sugar.
 - Modify the AST tree for triples to support the new features and to remove redundant nodes in the tree.
 - Rework blank node validation to make the implementation simpler (this results in minor changes to the error output).
+- Disallow syntax-quoting for symbols.
 
 ## v0.2.1
 

--- a/src/main/com/yetanalytics/flint/axiom/impl.cljc
+++ b/src/main/com/yetanalytics/flint/axiom/impl.cljc
@@ -168,7 +168,7 @@
 
   #?(:clj clojure.lang.Symbol :cljs Symbol)
   (-valid-wildcard? [sym] (= '* sym))
-  (-format-wildcard [sym] (name sym)))
+  (-format-wildcard [sym] (str sym)))
 
 (extend-protocol p/RDFType
   #?(:clj clojure.lang.Keyword :cljs Keyword)
@@ -177,7 +177,7 @@
 
   #?(:clj clojure.lang.Symbol :cljs Symbol)
   (-valid-rdf-type? [sym] (= 'a sym))
-  (-format-rdf-type [sym] (name sym)))
+  (-format-rdf-type [sym] (str sym)))
 
 ;; Defaults
 

--- a/src/main/com/yetanalytics/flint/axiom/impl/format.cljc
+++ b/src/main/com/yetanalytics/flint/axiom/impl/format.cljc
@@ -25,14 +25,14 @@
 (defn format-var-symbol
   "Return the var `v-sym` as a string of the form `?var`."
   [v-sym]
-  (name v-sym))
+  (str v-sym))
 
 (defn format-bnode-symbol
   "Return the bnode `b-sym` as a string of the form `_:bnode`. Returns
    `[]` if `b-sym` is a single underscore."
   [b-sym]
   (if (not= '_ b-sym)
-    (let [^String s  (name b-sym)
+    (let [^String s  (str b-sym)
           sub-string (.substring s 1 (count s))]
       (str "_:" sub-string))
     "[]"))

--- a/src/main/com/yetanalytics/flint/axiom/impl/validation.cljc
+++ b/src/main/com/yetanalytics/flint/axiom/impl/validation.cljc
@@ -580,13 +580,13 @@
 (defn valid-var-symbol?
   "Is `var-sym` a symbol that starts with `?`?"
   [var-sym]
-  (valid-var-str? (name var-sym)))
+  (valid-var-str? (str var-sym)))
 
 (defn valid-bnode-symbol?
   "Is `bnode-sym` a symbol that starts with `_` and has zero or more
    trailing chars?"
   [bnode-sym]
-  (valid-bnode-str? (name bnode-sym)))
+  (valid-bnode-str? (str bnode-sym)))
 
 ;; Literals
 
@@ -617,4 +617,3 @@
                   (string? lval)
                   (valid-lang-tag-str? (name ltag))
                   (valid-literal-str? lval)))))
-

--- a/src/main/com/yetanalytics/flint/error.cljc
+++ b/src/main/com/yetanalytics/flint/error.cljc
@@ -160,7 +160,7 @@
                      (->> nots (mapcat :variables) distinct sort)
                      (->> ins (map :variable) distinct sort))
         var-count  (->> var-coll count)
-        var-strs   (->> var-coll (map name))
+        var-strs   (->> var-coll (map str))
         var-str    (join-str-coll var-strs)]
     (fmt "%d variable%s%s in %d `expr AS var` clause%s %s %s defined in scope: %s!'"
          var-count
@@ -197,7 +197,7 @@
              (plural-has wild-count)))
       (let [var-coll (->> errs (mapcat :variables) distinct sort)
             var-count (->> var-coll count)
-            var-strs  (->> var-coll (map name))
+            var-strs  (->> var-coll (map str))
             var-str   (join-str-coll var-strs)]
         (fmt "%d variable%s%s %s illegally used in SELECTs with aggregates: %s!"
              var-count
@@ -220,7 +220,7 @@
   [bnode-err-m index-str]
   (let [bnode-coll  (->> bnode-err-m :errors (map :bnode) distinct)
         bnode-count (count bnode-coll)
-        bnode-strs  (->> bnode-coll (map name))
+        bnode-strs  (->> bnode-coll (map str))
         bnode-str   (if (= 1 bnode-count)
                       (first bnode-strs)
                       (fmt "%s and %s"

--- a/src/main/com/yetanalytics/flint/format/expr.cljc
+++ b/src/main/com/yetanalytics/flint/format/expr.cljc
@@ -26,7 +26,7 @@
 
 (defn- op->str
   [op]
-  (let [op-name (name op)]
+  (let [op-name (str op)]
     (case op-name
       "-"      "-" ; Otherwise will be removed below
       "not="   "!="

--- a/src/main/com/yetanalytics/flint/format/modifier.cljc
+++ b/src/main/com/yetanalytics/flint/format/modifier.cljc
@@ -3,7 +3,7 @@
             [com.yetanalytics.flint.format :as f]))
 
 (defmethod f/format-ast-node :mod/op [_ [_ op]]
-  (name op))
+  (str op))
 
 (defmethod f/format-ast-node :mod/asc-desc [_ [_ [op sub-expr]]]
   (let [op-name (cstr/upper-case op)]

--- a/src/test/com/yetanalytics/flint/spec/axiom_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/axiom_test.cljc
@@ -240,11 +240,14 @@
   (testing "variables"
     (is (s/valid? ax/variable-spec '?foo))
     (is (not (s/valid? ax/variable-spec "?foo")))
-    (is (not (s/valid? ax/variable-spec 'foo))))
+    (is (not (s/valid? ax/variable-spec 'foo)))
+    (is (not (s/valid? ax/variable-spec `?foo))))
   (testing "blank nodes"
     (is (s/valid? ax/bnode-spec '_))
     (is (s/valid? ax/bnode-spec '_foo))
-    (is (not (s/valid? ax/bnode-spec 'foo))))
+    (is (not (s/valid? ax/bnode-spec 'foo)))
+    (is (not (s/valid? ax/bnode-spec `_)))
+    (is (not (s/valid? ax/bnode-spec `_foo))))
   (testing "string literals"
     (is (s/valid? ax/literal-spec "foo bar"))
     (is (s/valid? ax/literal-spec "\\\"\\n\\r\\t\\\""))

--- a/src/test/com/yetanalytics/flint/spec/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/expr_test.cljc
@@ -188,7 +188,6 @@
   (testing "Invalid expressions due to syntax quoting"
     (is (not (s/valid? ::es/expr `(+ 2 2))))
     (is (not (s/valid? ::es/expr `(and true true))))
-    (is (not (s/valid? ::es/expr `(if true 1 0))))
     (is (not (s/valid? ::es/expr `(contains "foo" "foobar"))))))
 
 (deftest conform-expr-as-var-test

--- a/src/test/com/yetanalytics/flint/spec/expr_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/expr_test.cljc
@@ -184,7 +184,12 @@
                            :in     []}]
             ::s/spec ::es/expr
             ::s/value '(+)}
-           (s/explain-data ::es/expr '(+))))))
+           (s/explain-data ::es/expr '(+)))))
+  (testing "Invalid expressions due to syntax quoting"
+    (is (not (s/valid? ::es/expr `(+ 2 2))))
+    (is (not (s/valid? ::es/expr `(and true true))))
+    (is (not (s/valid? ::es/expr `(if true 1 0))))
+    (is (not (s/valid? ::es/expr `(contains "foo" "foobar"))))))
 
 (deftest conform-expr-as-var-test
   (testing "Conforming expr AS var clauses"

--- a/src/test/com/yetanalytics/flint/spec/path_test.cljc
+++ b/src/test/com/yetanalytics/flint/spec/path_test.cljc
@@ -139,4 +139,12 @@
                            :in     [1]}]
             ::s/spec ::ps/path
             ::s/value '(not (cat :foo/bar :bar/baz))}
-           (s/explain-data ::ps/path '(not (cat :foo/bar :bar/baz)))))))
+           (s/explain-data ::ps/path '(not (cat :foo/bar :bar/baz)))))
+    (testing "Invalid expressions due to syntax quoting"
+      (is (not (s/valid? ::ps/path `(alt :foo/bar :baz/qux))))
+      (is (not (s/valid? ::ps/path `(cat :foo/bar :baz/qux))))
+      (is (not (s/valid? ::ps/path `(inv :foo/bar))))
+      (is (not (s/valid? ::ps/path `(not :foo/bar))))
+      (is (not (s/valid? ::ps/path `(? :foo/bar))))
+      (is (not (s/valid? ::ps/path `(* :foo/bar))))
+      (is (not (s/valid? ::ps/path `(+ :foo/bar)))))))


### PR DESCRIPTION
Addresses an issue raised in #31 in which using backtick-quotes (like what is commonly used in Clojure macros) adds the namespace to variables and other symbols (though not consistently). This was unintentional behavior that is patched out in this PR.