### PR TITLE
Ensure zero-second times are valid

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       run: echo version=${GITHUB_REF#refs\/tags\/v} >> $GITHUB_OUTPUT
 
     - name: Build and deploy to Clojars
-      uses: yetanalytics/actions/deploy-clojars@v0.0.4
+      uses: yetanalytics/action-deploy-clojars@v1
       with:
           artifact-id: 'flint'
           resource-dirs: '[]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Modify the AST tree for triples to support the new features and to remove redundant nodes in the tree.
 - Rework blank node validation to make the implementation simpler (this results in minor changes to the error output).
 - Disallow syntax-quoting for symbols.
+- Fix bug where timestamps with zeroed-out seconds have the seconds omitted.
 
 ## v0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## v0.3.0
 
-- Add support for RDF List syntactic sugar.
-- Add support for blank node vector syntactic sugar.
-- Modify the AST tree for triples to support the new features and to remove redundant nodes in the tree.
+- Add support for SPARQL collections syntactic sugar:
+  - Add support for RDF list syntax.
+  - Add support for blank node vector syntax.
+- Modify the AST tree for triples to support the aforementioned features and to remove redundant nodes in the tree.
 - Rework blank node validation to make the implementation simpler (this results in minor changes to the error output).
 - Disallow syntax-quoting for symbols.
 - Fix bug where timestamps with zeroed-out seconds have the seconds omitted.

--- a/src/main/com/yetanalytics/flint/axiom/impl.cljc
+++ b/src/main/com/yetanalytics/flint/axiom/impl.cljc
@@ -68,6 +68,7 @@
       datatype IRI appended; `strval-fn` overrides the default `.toString` call.
       Without any kwargs, `(extend-xsd-literal t iri-suffix)` expands into:
       
+      ```
       (extend-type t p/Literal
         (-valid-literal?
           [_] true)
@@ -80,7 +81,8 @@
           [n] nil)
         (-format-literal-url
           ([n] (p/-format-literal-url n {}))
-          ([n opts] (fmt-impl/format-xsd-iri iri-suffix opts))))"
+          ([n opts] (fmt-impl/format-xsd-iri iri-suffix opts))))
+      ```"
      [t iri-suffix & {:keys [force-iri?
                              strval-fn]}]
      `(extend-type ~t
@@ -297,9 +299,40 @@
 ;; exceptions if `.toInstant` is directly called on them.
 
 #?(:clj
+   (defn- local-ts->local-str
+     [^java.time.LocalDateTime local-ts]
+     (.format java.time.format.DateTimeFormatter/ISO_LOCAL_DATE_TIME
+              local-ts)))
+
+#?(:clj
    (defn- zoned-ts->offset-str
      [^java.time.ZonedDateTime zoned-ts]
-     (.toString (.toOffsetDateTime zoned-ts))))
+     (.format java.time.format.DateTimeFormatter/ISO_OFFSET_DATE_TIME
+              (.toOffsetDateTime zoned-ts))))
+
+#?(:clj
+   (defn- offset-ts->offset-str
+     [^java.time.OffsetDateTime offset-ts]
+     (.format java.time.format.DateTimeFormatter/ISO_OFFSET_DATE_TIME
+              offset-ts)))
+
+#?(:clj
+   (defn- local-time->local-str
+     [^java.time.LocalTime local-time]
+     (.format java.time.format.DateTimeFormatter/ISO_LOCAL_TIME
+              local-time)))
+
+#?(:clj
+   (defn- offset-time->offset-str
+     [^java.time.OffsetTime offset-time]
+     (.format java.time.format.DateTimeFormatter/ISO_OFFSET_TIME
+              offset-time)))
+
+#?(:clj
+   (defn- local-date->local-str
+     [^java.time.LocalDate local-date]
+     (.format java.time.format.DateTimeFormatter/ISO_LOCAL_DATE
+              local-date)))
 
 #?(:clj
    (defn- date->inst-str
@@ -333,14 +366,19 @@
                          :strval-fn zoned-ts->offset-str
                          :force-iri? true)
      (extend-xsd-literal java.time.OffsetDateTime "dateTime"
+                         :strval-fn offset-ts->offset-str
                          :force-iri? true)
      (extend-xsd-literal java.time.OffsetTime "time"
+                         :strval-fn offset-time->offset-str
                          :force-iri? true)
      (extend-xsd-literal java.time.LocalDateTime "dateTime"
+                         :strval-fn local-ts->local-str
                          :force-iri? true)
      (extend-xsd-literal java.time.LocalDate "date"
+                         :strval-fn local-date->local-str
                          :force-iri? true)
      (extend-xsd-literal java.time.LocalTime "time"
+                         :strval-fn local-time->local-str
                          :force-iri? true)
      ;; java.util.Date classes
      (extend-xsd-literal java.util.Date "dateTime"

--- a/src/main/com/yetanalytics/flint/axiom/impl.cljc
+++ b/src/main/com/yetanalytics/flint/axiom/impl.cljc
@@ -65,7 +65,7 @@
    (defmacro extend-xsd-literal
      "Macro that expands into a basic `extend-type` over the Literal protocol.
       If `force-iri?` is true, then the resulting literal always has the XSD
-      datatype IRI appended; `strval-fn` overrides the default `.toString` call.
+      datatype IRI appended; `strval-fn` overrides the default call to `str`.
       Without any kwargs, `(extend-xsd-literal t iri-suffix)` expands into:
       
       ```
@@ -76,7 +76,7 @@
           ([n] (p/-format-literal n {}))
           ([n opts] (fmt-impl/format-literal n opts)))
         (-format-literal-strval
-          [n] (.toString n))
+          [n] (str n))
         (-format-literal-lang-tag
           [n] nil)
         (-format-literal-url
@@ -84,7 +84,8 @@
           ([n opts] (fmt-impl/format-xsd-iri iri-suffix opts))))
       ```"
      [t iri-suffix & {:keys [force-iri?
-                             strval-fn]}]
+                             strval-fn]
+                      :or {strval-fn str}}]
      `(extend-type ~t
         p/Literal
         (~'-valid-literal? [~'_] true)
@@ -95,9 +96,7 @@
               `(fmt-impl/format-literal ~'n (assoc ~'opts :force-iri? true))
               `(fmt-impl/format-literal ~'n ~'opts))))
         (~'-format-literal-strval [~'n]
-          ~(if (some? strval-fn)
-             `(~strval-fn ~'n)
-             `(.toString ~'n)))
+          (~strval-fn ~'n))
         (~'-format-literal-lang-tag [~'_] nil)
         (~'-format-literal-url
           ([~'n] (p/-format-literal-url ~'n {}))


### PR DESCRIPTION
Fix the issue #34 in which timestamps with zeroed-out seconds have the seconds part omitted, resulting in timestamps that no longer satisfy the `xsd:dateTime` or `xsd:date` specifications.