### PR TITLE
relax spec to allow cons result in filter clause

### DIFF
--- a/src/main/com/yetanalytics/flint/spec/expr.cljc
+++ b/src/main/com/yetanalytics/flint/spec/expr.cljc
@@ -331,12 +331,12 @@
     kwargs (conj [:expr/kwargs kwargs])))
 
 (def expr-branch-spec
-  (s/and list?
+  (s/and seq?
          expr-multi-spec
          (s/conformer conform-expr)))
 
 (def agg-expr-branch-spec
-  (s/and list?
+  (s/and seq?
          agg-expr-multi-spec
          (s/conformer conform-expr)))
 

--- a/src/test/com/yetanalytics/flint_test.cljc
+++ b/src/test/com/yetanalytics/flint_test.cljc
@@ -62,6 +62,14 @@
   (make-format-pretty-tests (fn [q] (format-query q :pretty? true))
                             "dev-resources/test-fixtures/inputs/query/"))
 
+(deftest cons-expression-test
+  (let [fclause (cons '= '(?v 5))]
+    (is (= "PREFIX ex: <http://ex.com/> SELECT ?e WHERE { ?e ex:value ?v . FILTER (?v = 5) }"
+           (format-query {:prefixes {:ex "<http://ex.com/>"}
+                          :select   '[?e]
+                          :where    ['[?e :ex/value ?v]
+                                     [:filter fclause]]})))))
+
 (deftest update-tests
   (make-format-tests format-update
                      "dev-resources/test-fixtures/inputs/update/")


### PR DESCRIPTION
As stated in #43, usage of `cons` in a filter query expression leads to a syntax error. Resolve this by replacing usage of the `list?` predicate with `seq?`